### PR TITLE
Fix Node Type

### DIFF
--- a/feddlib/amr/tests/flagTest/refinementFlag_area.cpp
+++ b/feddlib/amr/tests/flagTest/refinementFlag_area.cpp
@@ -28,7 +28,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/amr/tests/flagTest/refinementFlag_uniform.cpp
+++ b/feddlib/amr/tests/flagTest/refinementFlag_uniform.cpp
@@ -28,7 +28,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/General/DefaultTypeDefs.hpp
+++ b/feddlib/core/General/DefaultTypeDefs.hpp
@@ -1,7 +1,7 @@
 #ifndef DEFAULTTYPEDEFS_hpp
 #define DEFAULTTYPEDEFS_hpp
 #include <TpetraCore_config.h>
-#include <KokkosCompat_DefaultNode.hpp>
+#include <Tpetra_KokkosCompat_DefaultNode.hpp>
 
 typedef double default_sc;
 typedef int default_lo;
@@ -12,6 +12,6 @@ typedef int default_go;
 #else
 typedef long default_go;
 #endif
-typedef KokkosClassic::DefaultNode::DefaultNodeType default_no;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType default_no;
 
 #endif

--- a/feddlib/core/LinearAlgebra/tests/blockMatrixPtrAccess.cpp
+++ b/feddlib/core/LinearAlgebra/tests/blockMatrixPtrAccess.cpp
@@ -24,7 +24,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/LinearAlgebra/tests/blockView.cpp
+++ b/feddlib/core/LinearAlgebra/tests/blockView.cpp
@@ -24,7 +24,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/LinearAlgebra/tests/consistentPartitioning.cpp
+++ b/feddlib/core/LinearAlgebra/tests/consistentPartitioning.cpp
@@ -24,7 +24,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/LinearAlgebra/tests/map.cpp
+++ b/feddlib/core/LinearAlgebra/tests/map.cpp
@@ -24,7 +24,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/LinearAlgebra/tests/matrix.cpp
+++ b/feddlib/core/LinearAlgebra/tests/matrix.cpp
@@ -24,7 +24,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/LinearAlgebra/tests/matrix_assembly.cpp
+++ b/feddlib/core/LinearAlgebra/tests/matrix_assembly.cpp
@@ -24,7 +24,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/LinearAlgebra/tests/multivector.cpp
+++ b/feddlib/core/LinearAlgebra/tests/multivector.cpp
@@ -23,7 +23,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/Mesh/tests/AABBTree.cpp
+++ b/feddlib/core/Mesh/tests/AABBTree.cpp
@@ -28,7 +28,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 typedef Elements Elements_Type;
 typedef RCP<Elements_Type> ElementsPtr_Type;
 typedef Domain<SC,LO,GO,NO> Domain_Type;

--- a/feddlib/core/Mesh/tests/mesh_AABBTree.cpp
+++ b/feddlib/core/Mesh/tests/mesh_AABBTree.cpp
@@ -28,7 +28,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 typedef Elements Elements_Type;
 typedef RCP<Elements_Type> ElementsPtr_Type;
 

--- a/feddlib/core/Mesh/tests/mesh_elementFlags.cpp
+++ b/feddlib/core/Mesh/tests/mesh_elementFlags.cpp
@@ -27,7 +27,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/Mesh/tests/mesh_nodeFlagsP2.cpp
+++ b/feddlib/core/Mesh/tests/mesh_nodeFlagsP2.cpp
@@ -27,7 +27,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/Mesh/tests/mesh_structured.cpp
+++ b/feddlib/core/Mesh/tests/mesh_structured.cpp
@@ -23,7 +23,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/Mesh/tests/mesh_structured_3DCR.cpp
+++ b/feddlib/core/Mesh/tests/mesh_structured_3DCR.cpp
@@ -23,7 +23,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/Mesh/tests/mesh_structured_3DCR_BFS.cpp
+++ b/feddlib/core/Mesh/tests/mesh_structured_3DCR_BFS.cpp
@@ -23,7 +23,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/Mesh/tests/mesh_unstructured.cpp
+++ b/feddlib/core/Mesh/tests/mesh_unstructured.cpp
@@ -62,7 +62,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 using namespace FEDD;
 int main(int argc, char *argv[]) {
 

--- a/feddlib/core/Mesh/tests/meshes_custom_partition.cpp
+++ b/feddlib/core/Mesh/tests/meshes_custom_partition.cpp
@@ -76,7 +76,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 
 using namespace FEDD;
 using namespace Teuchos;

--- a/feddlib/core/Mesh/tests/meshes_interface.cpp
+++ b/feddlib/core/Mesh/tests/meshes_interface.cpp
@@ -78,7 +78,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 
 using namespace FEDD;
 using namespace Teuchos;

--- a/feddlib/problems/tests/fsi/main.cpp
+++ b/feddlib/problems/tests/fsi/main.cpp
@@ -138,7 +138,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 
 using namespace FEDD;
 using namespace Teuchos;

--- a/feddlib/problems/tests/fsi_artery/main.cpp
+++ b/feddlib/problems/tests/fsi_artery/main.cpp
@@ -96,7 +96,7 @@ typedef unsigned UN;
 typedef double SC;
 typedef int LO;
 typedef default_go GO;
-typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
+typedef Tpetra::KokkosClassic::DefaultNode::DefaultNodeType NO;
 
 using namespace FEDD;
 using namespace Teuchos;


### PR DESCRIPTION
Replacing `KokkosClassic::DefaultNode::DefaultNodeType` by `Tpetra::KokkosClassic::DefaultNode::DefaultNodeType` for compatibility with current Trilinos version.