### PR TITLE
MeshPartitioner and preconditioner optimization and code style fixes

### DIFF
--- a/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokesNonNewtonian_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokesNonNewtonian_decl.hpp
@@ -29,19 +29,19 @@ class AssembleFENavierStokesNonNewtonian : public AssembleFENavierStokes<SC,LO,G
 	/*!
 	 \brief Assemble the element Jacobian matrix.
 	*/
-	virtual void assembleJacobian();
+	void assembleJacobian() override;
 
 	/*!
 	 \brief Assemble the element right hand side vector.
 	*/
-	virtual void assembleRHS();
+	void assembleRHS() override;
 
 	//SmallMatrixPtr_Type getFixedPointMatrix(){return ANB_;};
 	/*!
 		\brief Assemble the element Jacobian matrix.
 		@param[in] block ID i
 	*/
-	virtual void assembleJacobianBlock(LO i) {};
+	void assembleJacobianBlock(LO i) override {};
 	//void setCoeff(SmallMatrix_Type coeff);
    protected:
 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokesNonNewtonian_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokesNonNewtonian_def.hpp
@@ -343,7 +343,7 @@ void AssembleFENavierStokes<SC,LO,GO,NO>::assemblyDivAndDivT(SmallMatrixPtr_Type
     }
 	//elementMatrix->print();
     // We compute value twice, maybe we should change this
-    /*for (UN i=0; i < dPhiTrans[0].size(); i++) {
+    for (UN i=0; i < dPhiTrans[0].size(); i++) {
 
         Teuchos::Array<Teuchos::Array<SC> >valueVec( dim, Teuchos::Array<SC>( phi->at(0).size(), 0. ) );
         Teuchos::Array<GO> indices( phi->at(0).size(), 0 );

--- a/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes_decl.hpp
@@ -28,18 +28,18 @@ class AssembleFENavierStokes : public AssembleFE<SC,LO,GO,NO> {
 	/*!
 	 \brief Assemble the element Jacobian matrix.
 	*/
-	virtual void assembleJacobian();
+	void assembleJacobian() override;
 
 	/*!
 	 \brief Assemble the element right hand side vector.
 	*/
-	virtual void assembleRHS();
+	void assembleRHS() override;
 
 	/*!
 		\brief Assemble the element Jacobian matrix.
 		@param[in] block ID i
 	*/
-	virtual void assembleJacobianBlock(LO i) {};
+	void assembleJacobianBlock(LO i) override {};
 	
 	void setCoeff(SmallMatrix_Type coeff);
 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_Laplace_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_Laplace_decl.hpp
@@ -37,19 +37,19 @@ class AssembleFE_Laplace : public AssembleFE<SC,LO,GO,NO> {
 	 \brief Assemble the element Jacobian matrix.
 	 \return the element Jacobian matrix
 	*/
-	virtual void assembleJacobian();
+	void assembleJacobian() override;
 
 	/*!
 	 \brief Assemble the element right hand side vector.
 	 \return the element right hand side vector
 	*/
-	virtual void assembleRHS();	
+	void assembleRHS() override;	
 
 	/*!
 		\brief Assemble the element Jacobian matrix.
 		@param[in] block ID i
 	*/
-	virtual void assembleJacobianBlock(LO i) {};
+	void assembleJacobianBlock(LO i) override {};
 
    protected:
 	AssembleFE_Laplace(int flag, vec2D_dbl_Type nodesRefConfig, ParameterListPtr_Type parameters,   tuple_disk_vec_ptr_Type tuple); /// \todo Tupel for Disk Anzahl Knoten, Anzahl Freiheitsgrade

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_LinElas_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_LinElas_decl.hpp
@@ -29,19 +29,19 @@ class AssembleFE_LinElas : public AssembleFE<SC,LO,GO,NO> {
 	 \brief Assemble the element Jacobian matrix.
 	 \return the element Jacobian matrix
 	*/
-	virtual void assembleJacobian() override;
+	void assembleJacobian() override;
 
 	/*!
 	 \brief Assemble the element right hand side vector.
 	 \return the element right hand side vector
 	*/
-	virtual void assembleRHS() override;	
+	void assembleRHS() override;	
 
 		/*!
 		\brief Assemble the element Jacobian matrix.
 		@param[in] block ID i
 	*/
-	virtual void assembleJacobianBlock(LO i) {};
+	void assembleJacobianBlock(LO i) override {};
 
    protected:
 	AssembleFE_LinElas(int flag, vec2D_dbl_Type nodesRefConfig, ParameterListPtr_Type parameters,   tuple_disk_vec_ptr_Type tuple); 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2_decl.hpp
@@ -29,24 +29,24 @@ class  AssembleFE_NonLinElas2 : public AssembleFE<SC,LO,GO,NO> {
 	 \brief Assemble the element Jacobian matrix.
 	 \return the element Jacobian matrix
 	*/
-	virtual void assembleJacobian();
+	void assembleJacobian() override;
 
 	/*!
 	 \brief Assemble the element right hand side vector.
 	 \return the element right hand side vector
 	*/
-	virtual void assembleRHS();	
+	void assembleRHS() override;	
 
 	/*!
 		\brief Assemble the element Jacobian matrix.
 		@param[in] block ID i
 	*/
-	virtual void assembleJacobianBlock(LO i) {};
+	void assembleJacobianBlock(LO i) override {};
 	/*!
 		\brief Update the parameter read from the ParameterList.
 		@param[in] Parameter as read from the xml file
 	*/
-    virtual void updateParameter(string type, double value);
+    void updateParameter(string type, double value) override;
 
    protected:
 	 AssembleFE_NonLinElas2(int flag, vec2D_dbl_Type nodesRefConfig, ParameterListPtr_Type parameters,   tuple_disk_vec_ptr_Type tuple); 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas_decl.hpp
@@ -29,24 +29,24 @@ class AssembleFE_NonLinElas : public AssembleFE<SC,LO,GO,NO> {
 	 \brief Assemble the element Jacobian matrix.
 	 \return the element Jacobian matrix
 	*/
-	virtual void assembleJacobian();
+	void assembleJacobian() override;
 
 	/*!
 	 \brief Assemble the element right hand side vector.
 	 \return the element right hand side vector
 	*/
-	virtual void assembleRHS();	
+	void assembleRHS() override;	
 
 	/*!
 		\brief Assemble the element Jacobian matrix.
 		@param[in] block ID i
 	*/
-	virtual void assembleJacobianBlock(LO i) {};
+	void assembleJacobianBlock(LO i) override {};
 	/*!
 		\brief Update the parameter read from the ParameterList.
 		@param[in] Parameter as read from the xml file
 	*/
-    virtual void updateParameter(string type, double value);
+    void updateParameter(string type, double value) override;
 
    protected:
 	AssembleFE_NonLinElas(int flag, vec2D_dbl_Type nodesRefConfig, ParameterListPtr_Type parameters,   tuple_disk_vec_ptr_Type tuple); 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH_decl.hpp
@@ -28,21 +28,21 @@ class AssembleFE_SCI_NH : public AssembleFE<SC,LO,GO,NO> {
 	    \brief Assemble the element Jacobian matrix.
 	    \return the element Jacobian matrix
 	    */
-	    virtual void assembleJacobian();
+	    void assembleJacobian() override;
 
         /*!
 	    \brief Assemble the element right hand side vector.
 	    \return the element right hand side vector
 	    */
-	    virtual void assembleRHS();
+	    void assembleRHS() override;
 
 		/*!
          \brief Assemble the element Jacobian matrix.
          @param[in] block ID i
         */
-        virtual void assembleJacobianBlock(LO i) {};
+        void assembleJacobianBlock(LO i) override {};
 
-		virtual void advanceInTime( double dt);
+		void advanceInTime( double dt) override;
 
     protected:
         AssembleFE_SCI_NH(int flag, vec2D_dbl_Type nodesRefConfig, ParameterListPtr_Type params,tuple_disk_vec_ptr_Type tuple);

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp
@@ -44,20 +44,20 @@ class AssembleFE_SCI_SMC_Active_Growth_Reorientation : public AssembleFE<SC,LO,G
         /*!
 	    \brief Assemble the element Jacobian matrix.
 	    */
-	    virtual void assembleJacobian();
+	    void assembleJacobian() override;
 
         /*!
 	    \brief Assemble the element right hand side vector.
 	    */
-	    virtual void assembleRHS();
+	    void assembleRHS() override;
 
  		/*!
 	    \brief Assemble block parts of the element Jacobian matrix.
 	    \return the element Jacobian matrix of block i 
 	    */
-		virtual void assembleJacobianBlock(LO i){};
+		void assembleJacobianBlock(LO i) override{};
 
-		virtual void advanceInTime(double dt);
+		void advanceInTime(double dt) override;
 
         void getMassMatrix(SmallMatrixPtr_Type &massMatrix ){massMatrix=massMatrix_;};
 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK_decl.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK_decl.hpp
@@ -39,20 +39,20 @@ class AssembleFE_SCI_SMC_MLCK : public AssembleFE<SC,LO,GO,NO> {
         /*!
 	    \brief Assemble the element Jacobian matrix.
 	    */
-	    virtual void assembleJacobian();
+	    void assembleJacobian() override;
 
         /*!
 	    \brief Assemble the element right hand side vector.
 	    */
-	    virtual void assembleRHS();
+	    void assembleRHS() override;
 
  		/*!
 	    \brief Assemble block parts of the element Jacobian matrix.
 	    \return the element Jacobian matrix of block i 
 	    */
-		virtual void assembleJacobianBlock(LO i){};
+		void assembleJacobianBlock(LO i) override{};
 
-		virtual void advanceInTime(double dt);
+		void advanceInTime(double dt) override;
 
 
     protected:

--- a/feddlib/core/Mesh/MeshPartitioner_def.hpp
+++ b/feddlib/core/Mesh/MeshPartitioner_def.hpp
@@ -358,50 +358,12 @@ void MeshPartitioner<SC,LO,GO,NO>::readAndPartitionMesh( int meshNumber ){
                 pointsRepIndices.push_back( eind[j] ); // Ids of element nodes, globalIDs
         }
     }
-    eind_vec.erase(eind_vec.begin(),eind_vec.end());
-    eptr_vec.erase(eptr_vec.begin(),eptr_vec.end());
-	
-	// Sorting ids with global and corresponding local values to creat repeated map
-    {
-        //Sollte in eigene Funktion
-        {
-            vector<int> index(pointsRepIndices.size(), 0);
-            for (int i = 0 ; i != index.size() ; i++) {
-                index.at(i) = i;
-            }
-            
-            sort(index.begin(), index.end(),
-                 [&](const int& a, const int& b) {
-                     return  pointsRepIndices[a] < pointsRepIndices[b];
-                 }
-                 );
-            
-            pointsRepIndices      = sort_from_ref(pointsRepIndices, index);
-        }
-        
-        //Sollte in eigene Funktion
-        {
-            vector<int> index(pointsRepIndices.size(), 0);
-            for (int i = 0 ; i != index.size() ; i++) {
-                index.at(i) = i;
-            }
-            
-            vector<int> ::iterator it;
-            
-            it = unique (index.begin(), index.end(),
-                         [&](const int& a, const int& b){
-                             if (pointsRepIndices.at(a) == pointsRepIndices.at(b)) {
-                                 return true;
-                             }
-                             else{
-                                 return false;
-                             }});
-            
-            pointsRepIndices = sort_from_ref(pointsRepIndices, index);
-            
-            pointsRepIndices.resize( distance( index.begin(), it ) );
-        }
-    }
+    // TODO KHo why erase the vectors here? eind points to the underlying array and is used later.
+    eind_vec.erase(eind_vec.begin(), eind_vec.end());
+    eptr_vec.erase(eptr_vec.begin(), eptr_vec.end());
+
+    // Sorting ids with global and corresponding local values to create repeated map
+    make_unique(pointsRepIndices);
     if (verbose)
         cout << "done!" << endl;
     

--- a/feddlib/problems/abstract/Problem_decl.hpp
+++ b/feddlib/problems/abstract/Problem_decl.hpp
@@ -94,7 +94,7 @@ public:
 
     Problem(ParameterListPtr_Type &parameterList, CommConstPtr_Type comm);
 
-    ~Problem();
+    virtual ~Problem() = default;
 
     virtual void info() = 0;
 

--- a/feddlib/problems/abstract/Problem_def.hpp
+++ b/feddlib/problems/abstract/Problem_def.hpp
@@ -76,11 +76,6 @@ namespace FEDD
     }
 
     template <class SC, class LO, class GO, class NO>
-    Problem<SC, LO, GO, NO>::~Problem()
-    {
-    }
-
-    template <class SC, class LO, class GO, class NO>
     void Problem<SC, LO, GO, NO>::infoProblem()
     {
         bool verbose(comm_->getRank() == 0);

--- a/feddlib/problems/specific/LinElasAssFE_def.hpp
+++ b/feddlib/problems/specific/LinElasAssFE_def.hpp
@@ -1,4 +1,4 @@
-#ifndef LINEALSASSFE_def_hpp
+#ifndef LINELASASSFE_def_hpp
 #define LINELASASSFE_def_hpp
 #include "LinElas_decl.hpp"
 namespace FEDD {

--- a/feddlib/problems/specific/LinElas_def.hpp
+++ b/feddlib/problems/specific/LinElas_def.hpp
@@ -1,4 +1,4 @@
-#ifndef LINEALS_def_hpp
+#ifndef LINELAS_def_hpp
 #define LINELAS_def_hpp
 #include "LinElas_decl.hpp"
 namespace FEDD {


### PR DESCRIPTION
+ readAndPartitionMesh makes better use of make_unique
+ preconditioner class does not build preconditioner unnecessarily when solving directly
+ header guard fixes
+ virtual override function fixes
+ virtual destructor of problem class fix