### PR TITLE
Cleaning up unused/redundant fields from mesh classes

### DIFF
--- a/feddlib/core/FE/Domain_decl.hpp
+++ b/feddlib/core/FE/Domain_decl.hpp
@@ -149,13 +149,6 @@ public:
     */
     LO getApproxEntriesPerRow() const;
 
-	/*!
-         \brief Set mesh parameter list
-         @param[in] pl Parameterlist
-
-    */
-    void setMeshParameterList( ParameterListPtr_Type& pl );
-    
     /*!
          \brief Get dimension
          \return dimension

--- a/feddlib/core/FE/Domain_def.hpp
+++ b/feddlib/core/FE/Domain_def.hpp
@@ -166,12 +166,6 @@ void Domain<SC,LO,GO,NO>::initializeFEData(){
 
     this->getElementsC()->initializeFEData( this->getPointsRepeated() );
 }
-
-template <class SC, class LO, class GO, class NO>
-void Domain<SC,LO,GO,NO>::setMeshParameterList( ParameterListPtr_Type& pl ){
-    TEUCHOS_TEST_FOR_EXCEPTION( mesh_.is_null(), std::runtime_error, "Mesh is null." );
-    mesh_->setParameterList( pl );
-}
     
 template <class SC, class LO, class GO, class NO>
 vec_int_ptr_Type Domain<SC,LO,GO,NO>::getElementsFlag() const{

--- a/feddlib/core/Mesh/MeshUnstructured_decl.hpp
+++ b/feddlib/core/Mesh/MeshUnstructured_decl.hpp
@@ -275,10 +275,6 @@ public:
  	string meshFileName_;
     string delimiter_;
 
-    int elementOrder_;
-    int surfaceElementOrder_;
-    int edgesElementOrder_;
-    int numElements_;
     int numSurfaces_;
     int numEdges_;
     int numNodes_;

--- a/feddlib/core/Mesh/MeshUnstructured_def.hpp
+++ b/feddlib/core/Mesh/MeshUnstructured_def.hpp
@@ -1342,7 +1342,6 @@ void MeshUnstructured<SC,LO,GO,NO>::readMeshSize(){
     this->elementOrder_ = orderElement;
     this->surfaceElementOrder_ = orderSurface;
     this->edgesElementOrder_ = orderEdges;
-    this->numElements_ = numElement;
     this->numSurfaces_ = numSurface;
     this->numEdges_ = numEdges;
     this->numNodes_ = numNode;
@@ -1470,11 +1469,11 @@ void MeshUnstructured<SC,LO,GO,NO>::readElements(){
     if (verbose)
         cout << "### Starting to read element data ... " << flush;
 
-    vec_int_Type    elementFlags( numElements_, 0 );
-    vec_int_Type    elementsCont( numElements_* elementOrder_, 0 );
+    vec_int_Type    elementFlags( this->numElementsGlob_, 0 );
+    vec_int_Type    elementsCont( this->numElementsGlob_* this->elementOrder_, 0 );
         
     // We need the edges of surface elements to use special surface flags, which are only set on 1D line segments. We need to save these edges to determine the correct flag of P2 elements which might be build later
-    meshReadData ( meshFileName_, "element", delimiter_, this->getDimension(), numElements_, elementOrder_, elementsCont, elementFlags );
+    meshReadData ( meshFileName_, "element", delimiter_, this->getDimension(), this->numElementsGlob_, this->elementOrder_, elementsCont, elementFlags );
 
     if (verbose){
         cout << "done." << endl;
@@ -1486,10 +1485,10 @@ void MeshUnstructured<SC,LO,GO,NO>::readElements(){
     
 	
     int id;
-    for (int i=0; i<numElements_; i++) {
-        vec_int_Type tmp(elementOrder_);
-        for (int j=0; j<elementOrder_; j++){
-            id = elementsCont.at(i*elementOrder_ + j) - 1;
+    for (int i=0; i<this->numElementsGlob_; i++) {
+        vec_int_Type tmp(this->elementOrder_);
+        for (int j=0; j<this->elementOrder_; j++){
+            id = elementsCont.at(i*this->elementOrder_ + j) - 1;
             tmp.at(j) = id;
         }
         FiniteElement fe( tmp , elementFlags[i] );
@@ -1508,10 +1507,10 @@ void MeshUnstructured<SC,LO,GO,NO>::readSurfaces(){
         cout << "### Starting to read surface data ... " << flush;
     
     vec_int_Type    surfaceFlags( numSurfaces_, 0 );
-    vec_int_Type    surfacesCont( numSurfaces_* surfaceElementOrder_, 0 );
+    vec_int_Type    surfacesCont( numSurfaces_* this->surfaceElementOrder_, 0 );
         
     // We need the edges of surface elements to use special surface flags, which are only set on 1D line segments. We need to save these edges to determine the correct flag of P2 elements which might be build later
-    meshReadData ( meshFileName_, "surface", delimiter_, this->getDimension(), numSurfaces_, surfaceElementOrder_, surfacesCont, surfaceFlags );
+    meshReadData ( meshFileName_, "surface", delimiter_, this->getDimension(), numSurfaces_, this->surfaceElementOrder_, surfacesCont, surfaceFlags );
         
     if (verbose){
         cout << "done." << endl;
@@ -1520,9 +1519,9 @@ void MeshUnstructured<SC,LO,GO,NO>::readSurfaces(){
     ElementsPtr_Type surfaceElementsMesh = this->getSurfaceElements();
     
     for (int i=0; i<numSurfaces_; i++) {
-        vec_int_Type tmp(surfaceElementOrder_);
-        for (int j=0; j<surfaceElementOrder_; j++)
-            tmp.at(j) = surfacesCont.at( i * surfaceElementOrder_ + j ) - 1;// -1 to have start index 0
+        vec_int_Type tmp(this->surfaceElementOrder_);
+        for (int j=0; j<this->surfaceElementOrder_; j++)
+            tmp.at(j) = surfacesCont.at( i * this->surfaceElementOrder_ + j ) - 1;// -1 to have start index 0
         
         //cout << " Reading surfaces " << tmp[0] << " " << tmp[1] << " " << tmp[2] << endl;
         //sort( tmp.begin(), tmp.end() ); // we sort here in order to identify the corresponding element faster! !!! We refrain from that so the numbering of surface element nodes remains the consisten with respct to normals.
@@ -1543,10 +1542,10 @@ void MeshUnstructured<SC,LO,GO,NO>::readLines(){
         cout << "### Starting to read line data ... " << flush;
 
     vec_int_Type    edgeFlags( numEdges_, 0 );
-    vec_int_Type    edgesCont( numEdges_* edgesElementOrder_, 0 );
+    vec_int_Type    edgesCont( numEdges_* this->edgesElementOrder_, 0 );
         
     // We need the edges of surface elements to use special surface flags, which are only set on 1D line segments. We need to save these edges to determine the correct flag of P2 elements which might be build later
-    meshReadData ( meshFileName_, "line", delimiter_, this->getDimension(), numEdges_, edgesElementOrder_, edgesCont, edgeFlags );
+    meshReadData ( meshFileName_, "line", delimiter_, this->getDimension(), numEdges_, this->edgesElementOrder_, edgesCont, edgeFlags );
 
     
     if (verbose){
@@ -1558,9 +1557,9 @@ void MeshUnstructured<SC,LO,GO,NO>::readLines(){
     
     //Continous edge surface elements to FiniteElement object (only relevant in 3D)
     for (int i=0; i<numEdges_; i++) {
-        vec_int_Type tmp(edgesElementOrder_);
-        for (int j=0; j<edgesElementOrder_; j++)
-            tmp.at(j) = edgesCont.at( i * edgesElementOrder_ + j ) - 1;// -1 to have start index 0
+        vec_int_Type tmp(this->edgesElementOrder_);
+        for (int j=0; j<this->edgesElementOrder_; j++)
+            tmp.at(j) = edgesCont.at( i * this->edgesElementOrder_ + j ) - 1;// -1 to have start index 0
         
         sort( tmp.begin(), tmp.end() ); // we sort here in order to identify the corresponding element faster!
         FiniteElement feEdge( tmp , edgeFlags[i] );

--- a/feddlib/core/Mesh/Mesh_decl.hpp
+++ b/feddlib/core/Mesh/Mesh_decl.hpp
@@ -165,6 +165,19 @@ public:
     /// @param displacementRepeated displacement in repeated dist.
     void moveMesh( MultiVectorPtr_Type displacementUnique, MultiVectorPtr_Type displacementRepeated );
     
+    /*!
+            \brief Get SurfaceElement order
+            \return surfaceElementOrder_
+    */
+    int getSurfaceElementOrder() { return surfaceElementOrder_; };
+
+    /*!
+            \brief Get EdgeElement order
+            \return edgesElementOrder_
+    */
+    int getEdgeElementOrder() { return edgesElementOrder_; };
+
+
     // Creates an AABBTree from own vertice- and elementlist.
     void create_AABBTree();
     
@@ -223,8 +236,6 @@ public:
 
     MapPtr_Type mapUniqueP2Map_;
     MapPtr_Type mapRepeatedP2Map_;
-    
-    ParameterListPtr_Type pList_;
 
     int elementOrder_;
     int surfaceElementOrder_;

--- a/feddlib/core/Mesh/Mesh_def.hpp
+++ b/feddlib/core/Mesh/Mesh_def.hpp
@@ -101,16 +101,6 @@ void Mesh<SC,LO,GO,NO>::setElementFlags(std::string type){
     }
 
 }
-
-template <class SC, class LO, class GO, class NO>
-void Mesh<SC,LO,GO,NO>::setParameterList( ParameterListPtr_Type& pL ) {
-    pList_ = pL;
-}
-
-template <class SC, class LO, class GO, class NO>
-ParameterListConstPtr_Type Mesh<SC,LO,GO,NO>::getParameterList( ) const{
-    return pList_;
-}
     
 template <class SC, class LO, class GO, class NO>
 vec_int_ptr_Type Mesh<SC,LO,GO,NO>::getElementsFlag() const{


### PR DESCRIPTION
The Mesh and UnstructuredMesh classes had some unused/redundant fields. This PR removes them.
