### PR TITLE
Remove unused P2 maps from Mesh class

### DIFF
--- a/feddlib/amr/tests/aneurysmBenchmark/main.cpp
+++ b/feddlib/amr/tests/aneurysmBenchmark/main.cpp
@@ -322,7 +322,7 @@ int main(int argc, char *argv[]) {
 			Teuchos::RCP<ExporterParaView<SC,LO,GO,NO> > exPara(new ExporterParaView<SC,LO,GO,NO>());
 			Teuchos::RCP<const MultiVector<SC,LO,GO,NO> > exportSolution = laplace.getSolution()->getBlock(0);
 			exPara->setup("solutionLaplace", domainVelocity->getMesh(), feTypeV); 
-		    exPara->addVariable(exportSolution, "u", "Scalar", 1, domainVelocity->getMapUnique(), domainVelocity->getMapUniqueP2());
+		    exPara->addVariable(exportSolution, "u", "Scalar", 1, domainVelocity->getMapUnique());
 		    exPara->save(0.0);
 	        
 			MAIN_TIMER_STOP(LaplaceInlet);	

--- a/feddlib/amr/tests/flagTest/refinementFlag_area.cpp
+++ b/feddlib/amr/tests/flagTest/refinementFlag_area.cpp
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
     
     exPara->setup( "NodeFlagsP2_area", domain->getMesh(), FEType );
     MultiVectorConstPtr_Type mvFlagConst = mvFlag;
-    exPara->addVariable( mvFlagConst, "Flags", "Scalar", 1, domain->getMapUnique(), domain->getMapUnique());
+    exPara->addVariable( mvFlagConst, "Flags", "Scalar", 1, domain->getMapUnique());
     
     exPara->save(0.0);
     exPara->closeExporter();

--- a/feddlib/amr/tests/flagTest/refinementFlag_uniform.cpp
+++ b/feddlib/amr/tests/flagTest/refinementFlag_uniform.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
     
     exPara->setup( "NodeFlagsP2_uniform", domain->getMesh(), FEType );
     MultiVectorConstPtr_Type mvFlagConst = mvFlag;
-    exPara->addVariable( mvFlagConst, "Flags", "Scalar", 1, domain->getMapUnique(), domain->getMapUnique());
+    exPara->addVariable( mvFlagConst, "Flags", "Scalar", 1, domain->getMapUnique());
     
     exPara->save(0.0);
     exPara->closeExporter();

--- a/feddlib/amr/tests/steadyNonLinElasAssFE/main.cpp
+++ b/feddlib/amr/tests/steadyNonLinElasAssFE/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
 
 		exParaF->setup("Flags", domain->getMesh(), FEType);
 
-		exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domain->getMapUnique(), domain->getMapUniqueP2());
+		exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domain->getMapUnique());
 
 		exParaF->save(0.0);
 

--- a/feddlib/amr/tests/unsteadyNonLinElasticity/main.cpp
+++ b/feddlib/amr/tests/unsteadyNonLinElasticity/main.cpp
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
 
 		exParaF->setup("Flags", domain->getMesh(), FEType);
 
-		exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domain->getMapUnique(), domain->getMapUniqueP2());
+		exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domain->getMapUnique());
 
 		exParaF->save(0.0);
 

--- a/feddlib/amr/tests/unsteadyReactionDiffusion/main.cpp
+++ b/feddlib/amr/tests/unsteadyReactionDiffusion/main.cpp
@@ -277,7 +277,7 @@ int main(int argc, char *argv[]) {
 
             exPara->setup("solutionDiffusionReaction", domain->getMesh(), FEType);
             
-            exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique(), domain->getMapUniqueP2());
+            exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique());
 
             exPara->save(0.0);
 

--- a/feddlib/core/FE/Domain_decl.hpp
+++ b/feddlib/core/FE/Domain_decl.hpp
@@ -171,20 +171,6 @@ public:
     MapConstPtr_Type getMapRepeated() const;
 
     /*!
-         \brief Get map of uniquely distributed P2 nodes of the processors.
-         \return mapUniqueP2
-
-    */
-    MapConstPtr_Type getMapUniqueP2() const;
-
-    /*!
-         \brief Get map of repeated (not uniquely distributed) P1 nodes of processors
-         \return mapRepeatedP2
-
-    */
-    MapConstPtr_Type getMapRepeatedP2() const;
-    
-    /*!
          \brief Get map of elements
          \return elementMap
 

--- a/feddlib/core/FE/Domain_def.hpp
+++ b/feddlib/core/FE/Domain_def.hpp
@@ -457,18 +457,6 @@ typename Domain<SC,LO,GO,NO>::MapConstPtr_Type Domain<SC,LO,GO,NO>::getMapRepeat
 }
 
 template <class SC, class LO, class GO, class NO>
-typename Domain<SC,LO,GO,NO>::MapConstPtr_Type Domain<SC,LO,GO,NO>::getMapUniqueP2() const{
-
-    return mesh_->getMapUniqueP2();
-}
-
-template <class SC, class LO, class GO, class NO>
-typename Domain<SC,LO,GO,NO>::MapConstPtr_Type Domain<SC,LO,GO,NO>::getMapRepeatedP2() const{
-
-    return mesh_->getMapRepeatedP2();
-}
-
-template <class SC, class LO, class GO, class NO>
 typename Domain<SC,LO,GO,NO>::MapConstPtr_Type Domain<SC,LO,GO,NO>::getElementMap() const{
 
     return mesh_->getElementMap();
@@ -1129,7 +1117,7 @@ void Domain<SC, LO, GO, NO>::exportElementFlags(string name)
 
         exPara->setup("Mesh_Element_Flags_"+name,this->getMesh(), "P0");
 
-        exPara->addVariable(exportSolutionConst, "Flags", "Scalar", 1,this->getElementMap(), this->getElementMap());
+        exPara->addVariable(exportSolutionConst, "Flags", "Scalar", 1,this->getElementMap());
 
         exPara->save(0.0);
 

--- a/feddlib/core/General/ExporterParaView_decl.hpp
+++ b/feddlib/core/General/ExporterParaView_decl.hpp
@@ -122,8 +122,7 @@ public:
                      std::string varName,
                      std::string varType,
                      int dofPerNode,
-                     MapConstPtrConst_Type& mapUnique=Teuchos::null,
-                     MapConstPtrConst_Type& mapUniqueLeading=Teuchos::null);
+                     MapConstPtrConst_Type& mapUnique=Teuchos::null);
     
     void save(double time);
     

--- a/feddlib/core/General/ExporterParaView_def.hpp
+++ b/feddlib/core/General/ExporterParaView_def.hpp
@@ -392,8 +392,7 @@ void ExporterParaView<SC,LO,GO,NO>::addVariable(MultiVecConstPtr_Type &u,
                                                   std::string varName,
                                                   std::string varType,
                                                   int dofPerNode,
-                                                  MapConstPtrConst_Type& mapUnique,
-                                                  MapConstPtrConst_Type& mapUniqueLeading){
+                                                  MapConstPtrConst_Type& mapUnique){
 
     variables_.push_back(u);
     varNames_.push_back(varName);

--- a/feddlib/core/Mesh/Mesh_decl.hpp
+++ b/feddlib/core/Mesh/Mesh_decl.hpp
@@ -81,17 +81,9 @@ public:
     /// @return mapRepeated_
     MapConstPtr_Type getMapRepeated() const;
 
-    /// @brief Getter for unique node P2 map. Dont know what this is for exactly. Think this object is empty
-    /// @return 
-    MapConstPtr_Type getMapUniqueP2() const;
-    
-    /// @brief Getter for repeated node P2 map. Dont know what this is for exactly. Think this object is empty
-    /// @return 
-    MapConstPtr_Type getMapRepeatedP2() const;
-    
     /// @brief Getter for element map 
     /// @return 
-    MapConstPtr_Type getElementMap();
+    MapConstPtr_Type getElementMap() const;
 	
     /// @brief Getter for edge map
     /// @return 
@@ -233,9 +225,6 @@ public:
     vec2D_dbl_ptr_Type		pointsUniRef_; // Unique Referenzkonfiguration
     
     //vec_int_ptr_Type 		elementFlag_;
-
-    MapPtr_Type mapUniqueP2Map_;
-    MapPtr_Type mapRepeatedP2Map_;
 
     int elementOrder_;
     int surfaceElementOrder_;

--- a/feddlib/core/Mesh/Mesh_def.hpp
+++ b/feddlib/core/Mesh/Mesh_def.hpp
@@ -31,8 +31,6 @@ elementMap_(),
 comm_(),
 pointsRepRef_(),
 pointsUniRef_(),
-mapUniqueP2Map_(),
-mapRepeatedP2Map_(),
 AABBTree_()
 {
 
@@ -58,8 +56,6 @@ edgeMap_(),
 comm_(comm),
 pointsRepRef_(),
 pointsUniRef_(),
-mapUniqueP2Map_(),
-mapRepeatedP2Map_(),
 AABBTree_()
 {
     AABBTree_.reset(new AABBTree_Type());
@@ -122,19 +118,7 @@ typename Mesh<SC,LO,GO,NO>::MapConstPtr_Type Mesh<SC,LO,GO,NO>::getMapRepeated()
 }
 
 template <class SC, class LO, class GO, class NO>
-typename Mesh<SC,LO,GO,NO>::MapConstPtr_Type Mesh<SC,LO,GO,NO>::getMapUniqueP2() const{
-
-    return mapUniqueP2Map_;
-}
-
-template <class SC, class LO, class GO, class NO>
-typename Mesh<SC,LO,GO,NO>::MapConstPtr_Type Mesh<SC,LO,GO,NO>::getMapRepeatedP2() const{
-
-    return mapRepeatedP2Map_;
-}
-
-template <class SC, class LO, class GO, class NO>
-typename Mesh<SC,LO,GO,NO>::MapConstPtr_Type Mesh<SC,LO,GO,NO>::getElementMap(){
+typename Mesh<SC,LO,GO,NO>::MapConstPtr_Type Mesh<SC,LO,GO,NO>::getElementMap() const{
     TEUCHOS_TEST_FOR_EXCEPTION( elementMap_.is_null(), std::runtime_error, "Element map of mesh does not exist." );
     return elementMap_;
 }

--- a/feddlib/core/Mesh/tests/mesh_nodeFlagsP2.cpp
+++ b/feddlib/core/Mesh/tests/mesh_nodeFlagsP2.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
     
     exPara->setup( "NodeFlagsP2", domain->getMesh(), "P2" );
     MultiVectorConstPtr_Type mvFlagConst = mvFlag;
-    exPara->addVariable( mvFlagConst, "Flags", "Scalar", 1, domain->getMapUnique(), domain->getMapUnique());
+    exPara->addVariable( mvFlagConst, "Flags", "Scalar", 1, domain->getMapUnique());
     
     exPara->save(0.0);
     exPara->closeExporter();

--- a/feddlib/core/Mesh/tests/mesh_structured_5_element_subcube.cpp
+++ b/feddlib/core/Mesh/tests/mesh_structured_5_element_subcube.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
         
         exPara->setup( "Element5SubcubeMeshWithFlagsOption3", domain->getMesh(), FEType );
         MultiVectorConstPtr_Type mvFlagConst = mvFlag;
-        exPara->addVariable( mvFlagConst, "Flags", "Scalar", 1,domain->getMapUnique(), domain->getMapUnique());
+        exPara->addVariable( mvFlagConst, "Flags", "Scalar", 1,domain->getMapUnique());
         
         exPara->save(0.0);
         exPara->closeExporter();

--- a/feddlib/problems/examples/fsi_artery/main.cpp
+++ b/feddlib/problems/examples/fsi_artery/main.cpp
@@ -386,7 +386,7 @@ int main(int argc, char *argv[])
 
 						exPara->setup("FlagsFluid",domainFluidVelocity->getMesh(), discType);
 
-						exPara->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domainFluidVelocity->getMapUnique(), domainFluidVelocity->getMapUniqueP2());
+						exPara->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domainFluidVelocity->getMapUnique());
 
 						exPara->save(0.0);
 
@@ -404,7 +404,7 @@ int main(int argc, char *argv[])
 
 						exPara2->setup("FlagsStructure", domainStructure->getMesh(), discType);
 
-						exPara2->addVariable(exportSolutionConst2, "Flags", "Scalar", 1,domainStructure->getMapUnique(), domainStructure->getMapUniqueP2());
+						exPara2->addVariable(exportSolutionConst2, "Flags", "Scalar", 1,domainStructure->getMapUnique());
 
 						exPara2->save(0.0);
 

--- a/feddlib/problems/examples/fsi_arteryBenchmark/main.cpp
+++ b/feddlib/problems/examples/fsi_arteryBenchmark/main.cpp
@@ -386,7 +386,7 @@ int main(int argc, char *argv[])
 
 						exPara->setup("FlagsFluid",domainFluidVelocity->getMesh(), discType);
 
-						exPara->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domainFluidVelocity->getMapUnique(), domainFluidVelocity->getMapUniqueP2());
+						exPara->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domainFluidVelocity->getMapUnique());
 
 						exPara->save(0.0);
 
@@ -404,7 +404,7 @@ int main(int argc, char *argv[])
 
 						exPara2->setup("FlagsStructure", domainStructure->getMesh(), discType);
 
-						exPara2->addVariable(exportSolutionConst2, "Flags", "Scalar", 1,domainStructure->getMapUnique(), domainStructure->getMapUniqueP2());
+						exPara2->addVariable(exportSolutionConst2, "Flags", "Scalar", 1,domainStructure->getMapUnique());
 
 						exPara2->save(0.0);
 

--- a/feddlib/problems/examples/laplace/main.cpp
+++ b/feddlib/problems/examples/laplace/main.cpp
@@ -210,9 +210,9 @@ int main(int argc, char *argv[]) {
             exPara->setup("solutionLaplace", domain->getMesh(), FEType);
             
             if (vL)
-                exPara->addVariable(exportSolution, "u", "Vector", dim, domain->getMapUnique(), domain->getMapUniqueP2());
+                exPara->addVariable(exportSolution, "u", "Vector", dim, domain->getMapUnique());
             else
-                exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique(), domain->getMapUniqueP2());
+                exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique());
 
             exPara->save(0.0);
 

--- a/feddlib/problems/examples/laplaceBlocks/main.cpp
+++ b/feddlib/problems/examples/laplaceBlocks/main.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
             exPara->setup( domain->getDimension(), domain->getNumElementsGlobal(), domain->getElements(), domain->getPointsUnique(), domain->getMapUnique(), domain->getMapRepeated(), FEType, "solutionLaplace1", 1, comm );
 
 
-            exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique(), domain->getMapUniqueP2());
+            exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique());
 
             exPara->save(0.0);
 

--- a/feddlib/problems/examples/steadyGeneralizedNewtonian_PowerLaw/main.cpp
+++ b/feddlib/problems/examples/steadyGeneralizedNewtonian_PowerLaw/main.cpp
@@ -452,7 +452,7 @@ int main(int argc, char *argv[])
             }
             Teuchos::RCP<const MultiVector<SC, LO, GO, NO>> exportSolutionConst = exportSolution;
             exParaF->setup("Flags", domainVelocity->getMesh(), domainVelocity->getFEType());
-            exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1, domainVelocity->getMapUnique(), domainVelocity->getMapUniqueP2());
+            exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1, domainVelocity->getMapUnique());
             exParaF->save(0.0);
 
             //**************************** Plot Subdomains without overlap ****************************************

--- a/feddlib/problems/examples/unsteadyReactionDiffusion/main.cpp
+++ b/feddlib/problems/examples/unsteadyReactionDiffusion/main.cpp
@@ -249,7 +249,7 @@ int main(int argc, char *argv[]) {
 
             exPara->setup("solutionDiffusionReaction", domain->getMesh(), FEType);
             
-            exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique(), domain->getMapUniqueP2());
+            exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique());
 
             exPara->save(0.0);
 

--- a/feddlib/problems/tests/UnitTest/laplaceUnitTest.cpp
+++ b/feddlib/problems/tests/UnitTest/laplaceUnitTest.cpp
@@ -175,8 +175,8 @@ int main(int argc, char *argv[]) {
 
             exPara->setup("solutionLaplace", domain->getMesh(), FEType);
             
-            exPara->addVariable(exportSolution, "u_current", "Scalar", 1, domain->getMapUnique(), domain->getMapUniqueP2());
-            exPara->addVariable(solutionImported, "u_imported", "Scalar", 1, domain->getMapUnique(), domain->getMapUniqueP2());
+            exPara->addVariable(exportSolution, "u_current", "Scalar", 1, domain->getMapUnique());
+            exPara->addVariable(solutionImported, "u_imported", "Scalar", 1, domain->getMapUnique());
 
             exPara->save(0.0);
 

--- a/feddlib/problems/tests/UnitTest/nonLinLaplaceUnitTest.cpp
+++ b/feddlib/problems/tests/UnitTest/nonLinLaplaceUnitTest.cpp
@@ -226,7 +226,9 @@ int main(int argc, char *argv[]) {
         Teuchos::RCP<ExporterParaView<SC, LO, GO, NO>> exPara(new ExporterParaView<SC, LO, GO, NO>());
         Teuchos::RCP<const MultiVector<SC, LO, GO, NO>> exportSolution = nonLinLaplace.getSolution()->getBlock(0);
         exPara->setup("solutionNonLinLaplace", domain->getMesh(), FEType);
-        exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique(), domain->getMapUniqueP2());
+
+        exPara->addVariable(exportSolution, "u", "Scalar", 1, domain->getMapUnique());
+
         exPara->save(0.0);
     }
 

--- a/feddlib/problems/tests/steadyLinElasAssFE/main.cpp
+++ b/feddlib/problems/tests/steadyLinElasAssFE/main.cpp
@@ -233,7 +233,7 @@ int main(int argc, char *argv[])
 
 		exParaF->setup("Flags", domain->getMesh(), FEType);
 
-		exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domain->getMapUnique(), domain->getMapUniqueP2());
+		exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domain->getMapUnique());
 
 		exParaF->save(0.0);
 

--- a/feddlib/problems/tests/steadyNavierStokesAssFE/main.cpp
+++ b/feddlib/problems/tests/steadyNavierStokesAssFE/main.cpp
@@ -331,7 +331,7 @@ int main(int argc, char *argv[]) {
 
 			exPara->setup("FlagsFluid",domainVelocity->getMesh(), discVelocity);
 
-			exPara->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domainVelocity->getMapUnique(), domainVelocity->getMapUniqueP2());
+			exPara->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domainVelocity->getMapUnique());
 
 			exPara->save(0.0);
 			// ---------------------

--- a/feddlib/problems/tests/steadyNonLinElasAssFE/main.cpp
+++ b/feddlib/problems/tests/steadyNonLinElasAssFE/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
 
 		exParaF->setup("Flags", domain->getMesh(), FEType);
 
-		exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domain->getMapUnique(), domain->getMapUniqueP2());
+		exParaF->addVariable(exportSolutionConst, "Flags", "Scalar", 1,domain->getMapUnique());
 
 		exParaF->save(0.0);
 


### PR DESCRIPTION
These P2 maps were never being constructed. 
They were being passed into the addVariable() function of the exporter class, but also not used there. 