### PR TITLE
Remove instances where underlying lib is used to give a choice between Epetra and Tpetra.

### DIFF
--- a/feddlib/core/FE/Domain_def.hpp
+++ b/feddlib/core/FE/Domain_def.hpp
@@ -737,7 +737,6 @@ void Domain<SC,LO,GO,NO>::buildUniqueInterfaceMaps()
     GO numberInterfaceNodes = localInterfaceID; // long long wg. 64
     
     // Baue nun die InterfaceMap (node)
-    //std::string ulib = this->getMapUnique()->getUnderlyingLib();
     Teuchos::ArrayView<GO> vecInterfaceMapArray =  Teuchos::arrayViewFromVector( vecInterfaceMap );
     interfaceMapUnique_ = Teuchos::rcp(new Map_Type( numberInterfaceNodes, vecInterfaceMapArray, 0, comm_ ) ); //maybe numberInterfaceNodes instead of -1
     // dof-Map bauen

--- a/feddlib/core/FEDDCore.hpp
+++ b/feddlib/core/FEDDCore.hpp
@@ -1,6 +1,5 @@
 #ifndef FEDDCORE_hpp
 #define FEDDCORE_hpp
-#define UNDERLYING_LIB_TPETRA
 
 #define FEDD_TIMER
 #define FEDD_DETAIL_TIMER

--- a/feddlib/core/LinearAlgebra/BlockMap_decl.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMap_decl.hpp
@@ -73,8 +73,6 @@ public:
 
     void info();
     
-    std::string getUnderlyingLib( ) const;
-        
     /// @brief Getting merged map of block maps
     /// @return mergedMap
     MapConstPtr_Type getMergedMap();

--- a/feddlib/core/LinearAlgebra/BlockMap_def.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMap_def.hpp
@@ -110,13 +110,6 @@ void BlockMap<LO,GO,NO>::info( ){
 }
 
 template <class LO, class GO, class NO>
-std::string BlockMap<LO,GO,NO>::getUnderlyingLib( ) const{
-    TEUCHOS_TEST_FOR_EXCEPTION(blockMap_.size()==0,std::runtime_error,"BlockMap size is 0, there is no underlying Lib.");
-    TEUCHOS_TEST_FOR_EXCEPTION(blockMap_[0].is_null(),std::runtime_error,"BlockMap[0] is null.");
-    return blockMap_[0]->getUnderlyingLib();
-}
-
-template <class LO, class GO, class NO>
 typename BlockMap<LO,GO,NO>::MapConstPtr_Type BlockMap<LO,GO,NO>::getMergedMap() {
     if ( mergedMap_.is_null() )
         this->merge();

--- a/feddlib/core/LinearAlgebra/Map_Xpetra_decl.hpp
+++ b/feddlib/core/LinearAlgebra/Map_Xpetra_decl.hpp
@@ -52,13 +52,13 @@ public:
     
     Map_Xpetra( const Map_Type& mapIn );
     
-    Map_Xpetra(std::string lib,
+    Map_Xpetra(
         GO numGlobalElements,
         const Teuchos::ArrayView<const GO> &elementList,
         GO indexBase,
         const CommConstPtr_Type &comm);
 
-    Map_Xpetra(std::string lib,
+    Map_Xpetra(
         GO numGlobalElements,
         LO numLocalElements,
         GO indexBase,
@@ -67,8 +67,6 @@ public:
     
     ~Map_Xpetra();
     
-    std::string getUnderlyingLib( ) const;
-
     MapPtr_Type buildVecFieldMap(UN numDofs, std::string ordering="NodeWise") const;
     
     XpetraMapConstPtr_Type getXpetraMap() const;

--- a/feddlib/core/LinearAlgebra/Map_Xpetra_def.hpp
+++ b/feddlib/core/LinearAlgebra/Map_Xpetra_def.hpp
@@ -31,64 +31,34 @@ template < class LO, class GO, class NO>
 Map_Xpetra<LO,GO,NO>::Map_Xpetra( const Map_Type& mapIn ):
 map_()
 {
-    Xpetra::UnderlyingLib ulib;
-    if (!mapIn.getUnderlyingLib().compare("Epetra"))
-        ulib = Xpetra::UseEpetra;
-    else if (!mapIn.getUnderlyingLib().compare("Tpetra"))
-        ulib = Xpetra::UseTpetra;
-
-    map_ = Xpetra::MapFactory<LO,GO,NO>::Build( ulib, mapIn.getGlobalNumElements(), mapIn.getNodeElementList(), mapIn.getIndexBase(), mapIn.getComm() );
+    map_ = Xpetra::MapFactory<LO,GO,NO>::Build( Xpetra::UseTpetra, mapIn.getGlobalNumElements(), mapIn.getNodeElementList(), mapIn.getIndexBase(), mapIn.getComm() );
 }
     
 template < class LO, class GO, class NO>
-Map_Xpetra<LO,GO,NO>::Map_Xpetra(std::string lib,
+Map_Xpetra<LO,GO,NO>::Map_Xpetra(
                     GO numGlobalElements,
                     const Teuchos::ArrayView<const GO> &elementList,
                     GO indexBase,
                     const CommConstPtr_Type &comm):
 map_()
 {
-    Xpetra::UnderlyingLib ulib;
-    if (!lib.compare("Epetra"))
-        ulib = Xpetra::UseEpetra;
-    else if (!lib.compare("Tpetra"))
-        ulib = Xpetra::UseTpetra;
-    map_ = Xpetra::MapFactory<LO,GO,NO>::Build( ulib, numGlobalElements, elementList, indexBase, comm);
+    map_ = Xpetra::MapFactory<LO,GO,NO>::Build( Xpetra::UseTpetra, numGlobalElements, elementList, indexBase, comm);
 }
 
 template < class LO, class GO, class NO>
-Map_Xpetra<LO,GO,NO>::Map_Xpetra(std::string lib,
+Map_Xpetra<LO,GO,NO>::Map_Xpetra(
                    GO numGlobalElements,
                    LO numLocalElements,
                    GO indexBase,
                    const CommConstPtr_Type &comm):
 map_()
 {
-    Xpetra::UnderlyingLib ulib;
-    if (!lib.compare("Epetra"))
-        ulib = Xpetra::UseEpetra;
-    else if (!lib.compare("Tpetra"))
-        ulib = Xpetra::UseTpetra;
-    
-    map_ = Xpetra::MapFactory<LO,GO,NO>::Build( ulib, numGlobalElements, numLocalElements, indexBase, comm);
+    map_ = Xpetra::MapFactory<LO,GO,NO>::Build( Xpetra::UseTpetra, numGlobalElements, numLocalElements, indexBase, comm);
 }
     
 template < class LO, class GO, class NO>
 Map_Xpetra<LO,GO,NO>::~Map_Xpetra(){
     
-}
-
-template < class LO, class GO, class NO>
-std::string Map_Xpetra<LO,GO,NO>::getUnderlyingLib( ) const{
-    TEUCHOS_TEST_FOR_EXCEPTION(map_.is_null(),std::runtime_error,"map is null.");
-    std::string uLib;
-    if (map_->lib() == Xpetra::UseEpetra)
-        uLib = "Epetra";
-    else if (map_->lib() == Xpetra::UseTpetra)
-        uLib = "Tpetra";
-    else
-        TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"Unknown underlying lib");
-    return uLib;
 }
 
 template < class LO, class GO, class NO>
@@ -103,7 +73,7 @@ typename Map_Xpetra<LO,GO,NO>::MapPtr_Type Map_Xpetra<LO,GO,NO>::buildVecFieldMa
             elementListField[ numDofs * i + dof ] = numDofs * elementList[i] + dof;
     }
     typedef Teuchos::OrdinalTraits<GO> GOOT;
-    return Teuchos::rcp(new Map_Type( this->getUnderlyingLib(), GOOT::invalid(), elementListField(), map_->getIndexBase(), map_->getComm() ) );
+    return Teuchos::rcp(new Map_Type( GOOT::invalid(), elementListField(), map_->getIndexBase(), map_->getComm() ) );
 }
 
 template < class LO, class GO, class NO>
@@ -189,7 +159,7 @@ Teuchos::RCP<Map_Xpetra<LO,GO,NO> > Map_Xpetra<LO,GO,NO>::buildUniqueMap( int nu
         Teuchos::RCP<Xpetra::Vector<GO,LO,GO,NO> > myIndices = Xpetra::VectorFactory<GO,LO,GO,NO>::Build(map_);
         myIndices->putScalar(map_->getComm()->getRank()+1);
 
-        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMap = Xpetra::MapFactory<LO,GO,NO>::Build(map_->lib(),map_->getMaxAllGlobalIndex()+1,0,map_->getComm());
+        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMap = Xpetra::MapFactory<LO,GO,NO>::Build(Xpetra::UseTpetra,map_->getMaxAllGlobalIndex()+1,0,map_->getComm());
         Teuchos::RCP<Xpetra::Vector<GO,LO,GO,NO> > globalIndices = Xpetra::VectorFactory<GO,LO,GO,NO>::Build(linearMap);
 
         Teuchos::RCP<Xpetra::Import<LO,GO,NO> > importer = Xpetra::ImportFactory<LO,GO,NO>::Build(map_,linearMap);
@@ -204,7 +174,7 @@ Teuchos::RCP<Map_Xpetra<LO,GO,NO> > Map_Xpetra<LO,GO,NO>::buildUniqueMap( int nu
                 uniqueVector.push_back(map_->getGlobalElement(i));
             }
         }
-        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(map_->lib(),-1,uniqueVector(),0,map_->getComm());
+        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(Xpetra::UseTpetra,-1,uniqueVector(),0,map_->getComm());
         Teuchos::RCP<Map_Xpetra<LO,GO,NO> > map = Teuchos::rcp( new Map_Xpetra<LO,GO,NO>( mapXpetra ) );
         return  map;
     }
@@ -236,7 +206,7 @@ Teuchos::RCP<Map_Xpetra<LO,GO,NO> > Map_Xpetra<LO,GO,NO>::buildUniqueMap( int nu
             myElements[i] = i + offset;
         }
 
-        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMapAvailRanks = Xpetra::MapFactory<LO,GO,NO>::Build( map_->lib(),Teuchos::OrdinalTraits<GO>::invalid(), myElements(), 0, map_->getComm() );
+        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMapAvailRanks = Xpetra::MapFactory<LO,GO,NO>::Build( Xpetra::UseTpetra,Teuchos::OrdinalTraits<GO>::invalid(), myElements(), 0, map_->getComm() );
         
         Teuchos::RCP<Xpetra::Vector<GO,LO,GO,NO> > globalIndices = Xpetra::VectorFactory<GO,LO,GO,NO>::Build(linearMapAvailRanks);
         
@@ -254,7 +224,7 @@ Teuchos::RCP<Map_Xpetra<LO,GO,NO> > Map_Xpetra<LO,GO,NO>::buildUniqueMap( int nu
                 uniqueVector.push_back(map_->getGlobalElement(i));
             }
         }
-        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(map_->lib(),-1,uniqueVector(),0,map_->getComm());
+        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(Xpetra::UseTpetra,-1,uniqueVector(),0,map_->getComm());
         Teuchos::RCP<Map_Xpetra<LO,GO,NO> > map = Teuchos::rcp( new Map_Xpetra<LO,GO,NO>( mapXpetra ) );
         return  map;
     }
@@ -295,7 +265,7 @@ Teuchos::RCP<Map_Xpetra<LO,GO,NO> > Map_Xpetra<LO,GO,NO>::buildUniqueMap( tuple_
         myElements[i] = i + offset;
 
     
-    Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMapAvailRanks = Xpetra::MapFactory<LO,GO,NO>::Build( map_->lib(),Teuchos::OrdinalTraits<GO>::invalid(), myElements(), 0, map_->getComm() );
+    Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMapAvailRanks = Xpetra::MapFactory<LO,GO,NO>::Build( Xpetra::UseTpetra,Teuchos::OrdinalTraits<GO>::invalid(), myElements(), 0, map_->getComm() );
     
     Teuchos::RCP<Xpetra::Vector<GO,LO,GO,NO> > globalIndices = Xpetra::VectorFactory<GO,LO,GO,NO>::Build(linearMapAvailRanks);
     
@@ -313,7 +283,7 @@ Teuchos::RCP<Map_Xpetra<LO,GO,NO> > Map_Xpetra<LO,GO,NO>::buildUniqueMap( tuple_
             uniqueVector.push_back(map_->getGlobalElement(i));
         }
     }
-    Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(map_->lib(),-1,uniqueVector(),0,map_->getComm());
+    Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(Xpetra::UseTpetra,-1,uniqueVector(),0,map_->getComm());
     Teuchos::RCP<Map_Xpetra<LO,GO,NO> > map = Teuchos::rcp( new Map_Xpetra<LO,GO,NO>( mapXpetra ) );
 
     return  map;

--- a/feddlib/core/LinearAlgebra/Map_decl.hpp
+++ b/feddlib/core/LinearAlgebra/Map_decl.hpp
@@ -93,8 +93,6 @@ public:
 
     GO getIndexBase() const; 
 
-    std::string getUnderlyingLib( ) const;       
-    
     MapPtr_Type buildVecFieldMap(UN numDofs, std::string ordering="NodeWise") const;
    
     TpetraMapConstPtr_Type getTpetraMap() const;

--- a/feddlib/core/LinearAlgebra/Map_def.hpp
+++ b/feddlib/core/LinearAlgebra/Map_def.hpp
@@ -29,7 +29,6 @@ template < class LO, class GO, class NO>
 Map<LO,GO,NO>::Map( const Map_Type& mapIn ):
 map_()
 {
-    //mapX_ = Xpetra::MapFactory<LO,GO,NO>::Build( mapIn.getUnderlyingLib(), mapIn.getGlobalNumElements(), mapIn.getNodeElementList(), mapIn.getIndexBase(), mapIn.getComm() );
     map_ = Teuchos::RCP(new TpetraMap_Type(mapIn.getGlobalNumElements(), mapIn.getNodeElementList(),mapIn.getIndexBase(), mapIn.getComm()));
 
 }
@@ -101,16 +100,6 @@ template < class LO, class GO, class NO>
 Teuchos::ArrayView< const GO > Map<LO,GO,NO>::getNodeElementList() const{
     TEUCHOS_TEST_FOR_EXCEPTION(map_.is_null(),std::runtime_error,"map is null.");
     return map_->getLocalElementList();
-}
-
-template < class LO, class GO, class NO>
-std::string Map<LO,GO,NO>::getUnderlyingLib( ) const{
-    TEUCHOS_TEST_FOR_EXCEPTION(map_.is_null(),std::runtime_error,"map is null.");
-    std::string uLib;
-
-    uLib = "Tpetra";
-
-    return uLib;
 }
 
 template < class LO, class GO, class NO>
@@ -325,7 +314,7 @@ Teuchos::RCP<Map<LO,GO,NO> > Map<LO,GO,NO>::buildUniqueMap( int numFreeProcs ) c
         Teuchos::RCP<Xpetra::Vector<GO,LO,GO,NO> > myIndices = Xpetra::VectorFactory<GO,LO,GO,NO>::Build(map_);
         myIndices->putScalar(map_->getComm()->getRank()+1);
 
-        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMap = Xpetra::MapFactory<LO,GO,NO>::Build(map_->lib(),map_->getMaxAllGlobalIndex()+1,0,map_->getComm());
+        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMap = Xpetra::MapFactory<LO,GO,NO>::Build(map_->getMaxAllGlobalIndex()+1,0,map_->getComm());
         Teuchos::RCP<Xpetra::Vector<GO,LO,GO,NO> > globalIndices = Xpetra::VectorFactory<GO,LO,GO,NO>::Build(linearMap);
 
         Teuchos::RCP<Xpetra::Import<LO,GO,NO> > importer = Xpetra::ImportFactory<LO,GO,NO>::Build(map_,linearMap);
@@ -340,7 +329,7 @@ Teuchos::RCP<Map<LO,GO,NO> > Map<LO,GO,NO>::buildUniqueMap( int numFreeProcs ) c
                 uniqueVector.push_back(map_->getGlobalElement(i));
             }
         }
-        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(map_->lib(),-1,uniqueVector(),0,map_->getComm());
+        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(-1,uniqueVector(),0,map_->getComm());
         Teuchos::RCP<Map<LO,GO,NO> > map = Teuchos::rcp( new Map<LO,GO,NO>( mapXpetra ) );
         return  map;
     }
@@ -372,7 +361,7 @@ Teuchos::RCP<Map<LO,GO,NO> > Map<LO,GO,NO>::buildUniqueMap( int numFreeProcs ) c
             myElements[i] = i + offset;
         }
 
-        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMapAvailRanks = Xpetra::MapFactory<LO,GO,NO>::Build( map_->lib(),Teuchos::OrdinalTraits<GO>::invalid(), myElements(), 0, map_->getComm() );
+        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMapAvailRanks = Xpetra::MapFactory<LO,GO,NO>::Build( Teuchos::OrdinalTraits<GO>::invalid(), myElements(), 0, map_->getComm() );
         
         Teuchos::RCP<Xpetra::Vector<GO,LO,GO,NO> > globalIndices = Xpetra::VectorFactory<GO,LO,GO,NO>::Build(linearMapAvailRanks);
         
@@ -390,7 +379,7 @@ Teuchos::RCP<Map<LO,GO,NO> > Map<LO,GO,NO>::buildUniqueMap( int numFreeProcs ) c
                 uniqueVector.push_back(map_->getGlobalElement(i));
             }
         }
-        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(map_->lib(),-1,uniqueVector(),0,map_->getComm());
+        Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(-1,uniqueVector(),0,map_->getComm());
         Teuchos::RCP<Map<LO,GO,NO> > map = Teuchos::rcp( new Map<LO,GO,NO>( mapXpetra ) );
         return  map;
     }
@@ -431,7 +420,7 @@ Teuchos::RCP<Map<LO,GO,NO> > Map<LO,GO,NO>::buildUniqueMap( tuple_intint_Type ra
         myElements[i] = i + offset;
 
     
-    Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMapAvailRanks = Xpetra::MapFactory<LO,GO,NO>::Build( map_->lib(),Teuchos::OrdinalTraits<GO>::invalid(), myElements(), 0, map_->getComm() );
+    Teuchos::RCP<Xpetra::Map<LO,GO,NO> > linearMapAvailRanks = Xpetra::MapFactory<LO,GO,NO>::Build( Teuchos::OrdinalTraits<GO>::invalid(), myElements(), 0, map_->getComm() );
     
     Teuchos::RCP<Xpetra::Vector<GO,LO,GO,NO> > globalIndices = Xpetra::VectorFactory<GO,LO,GO,NO>::Build(linearMapAvailRanks);
     
@@ -449,7 +438,7 @@ Teuchos::RCP<Map<LO,GO,NO> > Map<LO,GO,NO>::buildUniqueMap( tuple_intint_Type ra
             uniqueVector.push_back(map_->getGlobalElement(i));
         }
     }
-    Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(map_->lib(),-1,uniqueVector(),0,map_->getComm());
+    Teuchos::RCP<Xpetra::Map<LO,GO,NO> > mapXpetra = Xpetra::MapFactory<LO,GO,NO>::Build(-1,uniqueVector(),0,map_->getComm());
     Teuchos::RCP<Map<LO,GO,NO> > map = Teuchos::rcp( new Map<LO,GO,NO>( mapXpetra ) );
 
     return  map;

--- a/feddlib/core/LinearAlgebra/Matrix_def.hpp
+++ b/feddlib/core/LinearAlgebra/Matrix_def.hpp
@@ -289,7 +289,6 @@ void Matrix<SC,LO,GO,NO>::scale(const SC& alpha) {
 template <class SC, class LO, class GO, class NO>
 void Matrix<SC,LO,GO,NO>::writeMM(std::string fileName) const{
     TEUCHOS_TEST_FOR_EXCEPTION( matrix_.is_null(), std::runtime_error,"Matrix in writeMM is null.");
-   // TEUCHOS_TEST_FOR_EXCEPTION( !(matrix_->getMap()->lib()==Xpetra::UseTpetra), std::logic_error,"Only available for Tpetra underlying lib.");
     //typedef Tpetra::CrsMatrix<SC,LO,GO,NO> TpetraCrsMatrix;
     //typedef Teuchos::RCP<TpetraCrsMatrix> TpetraCrsMatrixPtr;
 
@@ -308,7 +307,7 @@ void Matrix<SC,LO,GO,NO>::addMatrix(SC alpha, const MatrixPtr_Type &B, SC beta){
     //B = alpha*A + beta*B.
     if (B->isFillComplete())
         B->resumeFill();
-    TEUCHOS_TEST_FOR_EXCEPTION( B->isLocallyIndexed(), std::runtime_error,"Matrix in is locally index but Trilinos Epetra/Tpetra can not add to a matrix at this stage.");
+    TEUCHOS_TEST_FOR_EXCEPTION( B->isLocallyIndexed(), std::runtime_error,"Matrix in is locally index but Trilinos Tpetra cannot add to a matrix at this stage.");
     
     //const Tpetra::CrsMatrix<SC,LO,GO,NO>& tpA = Xpetra::Helpers<SC,LO,GO,NO>::Op2TpetraCrs(A);
     //Tpetra::CrsMatrix<SC,LO,GO,NO>& tpB = Xpetra::Helpers<SC,LO,GO,NO>::Op2NonConstTpetraCrs(B);

--- a/feddlib/core/LinearAlgebra/MultiVector_def.hpp
+++ b/feddlib/core/LinearAlgebra/MultiVector_def.hpp
@@ -183,8 +183,6 @@ Teuchos::RCP<const Thyra::MultiVectorBase<SC> > MultiVector<SC,LO,GO,NO>::getThy
 template <class SC, class LO, class GO, class NO>
 void MultiVector<SC,LO,GO,NO>::fromThyraMultiVector( Teuchos::RCP< Thyra::MultiVectorBase<SC> > thyraMV){
 
-    TEUCHOS_TEST_FOR_EXCEPTION( multiVector_.is_null(), std::runtime_error,"MultiVector is null but we need to know the underlying lib for function fromThyraMultiVector().");
-
     typedef Thyra::TpetraOperatorVectorExtraction<SC,LO,GO,NO> TOVE_Type;
     
     Teuchos::RCP<TpetraMultiVector_Type> tMV = TOVE_Type::getTpetraMultiVector( thyraMV );

--- a/feddlib/core/LinearAlgebra/tests/blockMatrixPtrAccess.cpp
+++ b/feddlib/core/LinearAlgebra/tests/blockMatrixPtrAccess.cpp
@@ -35,8 +35,6 @@ int main(int argc, char *argv[]) {
 
     // Command Line Parameters
     Teuchos::CommandLineProcessor myCLP;
-    string ulib_str = "Tpetra";
-    myCLP.setOption("ulib",&ulib_str,"Underlying lib");
     GO numGlobalElements = 4;
     myCLP.setOption("nge",&numGlobalElements,"numGlobalElements.");
 

--- a/feddlib/core/LinearAlgebra/tests/consistentPartitioning.cpp
+++ b/feddlib/core/LinearAlgebra/tests/consistentPartitioning.cpp
@@ -35,8 +35,6 @@ int main(int argc, char *argv[]) {
     int rank = comm->getRank();
     // Command Line Parameters
     Teuchos::CommandLineProcessor myCLP;
-    string ulib_str = "Tpetra";
-    myCLP.setOption("ulib",&ulib_str,"Underlying lib");
     GO numGlobalElements1 = 10;
     myCLP.setOption("nge1",&numGlobalElements1,"numGlobalElements1.");
     GO numGlobalElements2 = 20;
@@ -70,8 +68,6 @@ int main(int argc, char *argv[]) {
     typedef BlockMap<LO,GO,NO> BlockMap_Type;
     typedef RCP<BlockMap_Type> BlockMapPtr_Type;
 
-    TEUCHOS_TEST_FOR_EXCEPTION( ulib_str != "Tpetra", std::runtime_error,"Only Tpetra available.");
-
     MapConstPtr_Type map1;
     MapConstPtr_Type map2;
     MapConstPtr_Type map3;
@@ -81,7 +77,7 @@ int main(int argc, char *argv[]) {
     {
         Teuchos::Array<GO> indices(1);
         indices[0] = comm->getRank();
-        map1 = rcp( new Map_Type( ulib_str, (GO) -1, indices(), 0, comm ) );
+        map1 = rcp( new Map_Type( (GO) -1, indices(), 0, comm ) );
         MultiVectorPtr_Type part1 = rcp( new MultiVector_Type( map1 ) );
         part1->putScalar(2.);
         MultiVectorPtr_Type part2 = rcp( new MultiVector_Type( map1 ) );
@@ -95,7 +91,7 @@ int main(int argc, char *argv[]) {
             indices.push_back(0); indices.push_back(1);
         }
         
-        map2 = rcp( new Map_Type( ulib_str, (GO) -1, indices(), 0, comm ) );
+        map2 = rcp( new Map_Type( (GO) -1, indices(), 0, comm ) );
         MultiVectorPtr_Type part1 = rcp( new MultiVector_Type( map2 ) );
         part1->putScalar(2.);
         b->addBlock( part1, 0);
@@ -105,7 +101,7 @@ int main(int argc, char *argv[]) {
         if (rank==1){
             indices.push_back(0); indices.push_back(1);
         }
-        map3 = rcp( new Map_Type( ulib_str, (GO) -1, indices(), 0, comm ) );
+        map3 = rcp( new Map_Type( (GO) -1, indices(), 0, comm ) );
         MultiVectorPtr_Type part2 = rcp( new MultiVector_Type( map3 ) );
         part2->putScalar(3.);
         b->addBlock( part2, 1);
@@ -116,7 +112,7 @@ int main(int argc, char *argv[]) {
 
         indices.push_back(0);
         Teuchos::RCP<const Teuchos::Comm<LO> > commSerial = rcp(new Teuchos::MpiComm<LO>(MPI_COMM_SELF));
-        map4dotRes = rcp( new Map_Type( ulib_str, (GO) -1, indices(), 0, commSerial ) );
+        map4dotRes = rcp( new Map_Type( (GO) -1, indices(), 0, commSerial ) );
     }
 
     Array< ScalarTraits<SC>::magnitudeType> dots(1);

--- a/feddlib/core/LinearAlgebra/tests/map.cpp
+++ b/feddlib/core/LinearAlgebra/tests/map.cpp
@@ -35,8 +35,6 @@ int main(int argc, char *argv[]) {
 
     // Command Line Parameters
     Teuchos::CommandLineProcessor myCLP;
-    string ulib_str = "Tpetra";
-    myCLP.setOption("ulib",&ulib_str,"Underlying lib");
     GO numGlobalElements = 10;
     myCLP.setOption("nge",&numGlobalElements,"numGlobalElements.");
 
@@ -55,15 +53,12 @@ int main(int argc, char *argv[]) {
     typedef Map_Xpetra<LO,GO,NO> Map_Type;
     typedef RCP<Map_Type> MapPtr_Type;
 
-    TEUCHOS_TEST_FOR_EXCEPTION(!(!ulib_str.compare("Tpetra") || !ulib_str.compare("Epetra") ) , std::runtime_error,"Unknown algebra type");
-
-
     Array<GO> indices(numGlobalElements);
     for (UN i=0; i<indices.size(); i++) {
         indices[i] = i;
     }
 
-    MapPtr_Type map = rcp( new Map_Type(ulib_str, commWorld->getSize()*numGlobalElements, indices(), 0, commWorld) );
+    MapPtr_Type map = rcp( new Map_Type( commWorld->getSize()*numGlobalElements, indices(), 0, commWorld) );
 
     map->print();
 

--- a/feddlib/core/Mesh/MeshPartitioner_def.hpp
+++ b/feddlib/core/Mesh/MeshPartitioner_def.hpp
@@ -232,10 +232,6 @@ void MeshPartitioner<SC,LO,GO,NO>::readAndPartitionMesh( int meshNumber ){
             
     typedef Teuchos::OrdinalTraits<GO> OTGO;
 
-#ifdef UNDERLYING_LIB_TPETRA
-    string underlyingLib = "Tpetra";
-#endif
-    
     MeshUnstrPtr_Type meshUnstr = Teuchos::rcp_dynamic_cast<MeshUnstr_Type>( domains_[meshNumber]->getMesh() );
     
 	// Reading nodes

--- a/feddlib/core/Mesh/MeshStructured_decl.hpp
+++ b/feddlib/core/Mesh/MeshStructured_decl.hpp
@@ -52,44 +52,37 @@ public:
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void buildMesh2D(std::string FEType,
                     int N,
                     int M,
-                    int numProcsCoarseSolve=0,
-                    std::string underlyingLib="Tpetra");
+                    int numProcsCoarseSolve=0);
 
     /// @brief  Building 2D TPM rectangular mesh with the lenght and height as defined per 'setGeomerty2DRectangle' - characterized by building addition line segments for boundary conditions 
     /// @param FEType Finite element discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void buildMesh2DTPM(std::string FEType,
                         int N,
                         int M,
-                        int numProcsCoarseSolve=0,
-                        std::string underlyingLib="Tpetra");
+                        int numProcsCoarseSolve=0);
     
     /// @brief Building general 3D cuboid with length, width and height as defines by 'setGeometry3DBox'. Called by Domain class and different discretizations for 3D mesh are called within this functions.
     /// @param FEType Finite element discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void buildMesh3D(std::string FEType,
                      int N,
                      int M,
-                     int numProcsCoarseSolve=0,
-                     std::string underlyingLib="Tpetra");
+                     int numProcsCoarseSolve=0);
 
     /// @brief Building general 3D cuboid with length, width and height as defines by 'setGeometry3DBox'. Called by Domain class. Only P2 discretization available. Subcubes are build with 5 elements
     /// @param FEType Finite element discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
-    void buildMesh3D5Elements(std::string FEType, int N, int M, int numProcsCoarseSolve, std::string underlyingLib="Tpetra");
+    void buildMesh3D5Elements(std::string FEType, int N, int M, int numProcsCoarseSolve);
 
     
     /// @brief Building 2D backward facing step geometry with the lenght and height as defined per 'setGeomerty2DRectangle'. Called by Domain class and different discretizations for 2D mesh are called within this functions.
@@ -97,97 +90,79 @@ public:
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void buildMesh2DBFS(std::string FEType,
                      int N,
                      int M,
-                     int numProcsCoarseSolve=0,
-                     std::string underlyingLib="Tpetra");
+                     int numProcsCoarseSolve=0);
 
     /// @brief Building general 3D backward facing step with length, width and height as defines by 'setGeometry3DBox'. Called by Domain class and different discretizations for 3D mesh are called within this functions.
     /// @param FEType Finite element discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void buildMesh3DBFS(std::string FEType,
                         int N,
                         int M,
-                        int numProcsCoarseSolve=0,
-                        std::string underlyingLib="Tpetra");
+                        int numProcsCoarseSolve=0);
     
     /// @brief Building general 3D backward facing step with length, width and height as defines by 'setGeometry3DBox' with Q2-P1 discontinous discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library  
     void buildP1_Disc_Q2_3DBFS(int N,
                             int M,
-                            int numProcsCoarseSolve,
-                            std::string underlyingLib);
+                            int numProcsCoarseSolve);
 
     /// @brief Building general 3D cuboid with length, width and height as defines by 'setGeometry3DBox' with Q2-P1 discontinous discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void buildP1_Disc_Q2_3DCube(int N,
                                int M,
-                               int numProcsCoarseSolve,
-                               std::string underlyingLib);
+                               int numProcsCoarseSolve);
 
     /// @brief Building general 3D cuboid with length, width and height as defines by 'setGeometry3DBox' with Q1 discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void build3DQ1Cube(int N,
                        int M,
-                       int numProcsCoarseSolve,
-                       std::string underlyingLib );
+                       int numProcsCoarseSolve);
 
     /// @brief Building general 3D cuboid with length, width and height as defines by 'setGeometry3DBox' with Q2 discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
    void build3DQ2Cube( int N,
                         int M,
-                        int numProcsCoarseSolve,
-                        std::string underlyingLib );
+                        int numProcsCoarseSolve);
 
     /// @brief Building general 3D cuboid with length, width and height as defines by 'setGeometry3DBox' with Q2 discretization and 20?
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void build3DQ2_20Cube(int N,
                           int M,
-                          int numProcsCoarseSolve,
-                          std::string underlyingLib ); 
+                          int numProcsCoarseSolve); 
 
 
     /// @brief Building general 3D backward facing step with length, width and height as defines by 'setGeometry3DBox' with Q2 discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
     void build3DQ2BFS( int N,
                        int M,
-                       int numProcsCoarseSolve,
-                       std::string underlyingLib );
+                       int numProcsCoarseSolve);
     
     /// @brief  Building 2D mini TPM rectangular mesh with the lenght and height as defined per 'setGeomerty2DRectangle' - characterized by building addition line segments for boundary conditions 
     /// @param FEType Finite element discretization
     /// @param N Number of subdomains
     /// @param M H/h with H subdomain diameter (length/H) and h characteristic mesh size (length/(M*N))
     /// @param numProcsCoarseSolve if we want to reserve certain processors for coarse solve
-    /// @param underlyingLib underlying linear algebra library 
    void buildMesh2DMiniTPM(std::string FEType,
                             int N,
                             int M,
-                            int numProcsCoarseSolve=0,                            
-                            std::string underlyingLib="Tpetra" );
+                            int numProcsCoarseSolve=0);
 
     /// @brief Building suface lines for TPM square mini. Empty.
     /// @param feType 

--- a/feddlib/core/Mesh/MeshStructured_def.hpp
+++ b/feddlib/core/Mesh/MeshStructured_def.hpp
@@ -68,10 +68,9 @@ template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildMesh2DTPM(std::string FEType,
                                               int N,
                                               int M,
-                                              int numProcsCoarseSolve,
-                                              std::string underlyingLib){
+                                              int numProcsCoarseSolve){
 
-    buildMesh2D( FEType, N, M, numProcsCoarseSolve, underlyingLib );
+    buildMesh2D( FEType, N, M, numProcsCoarseSolve );
 
     setRankRange( numProcsCoarseSolve );
 
@@ -83,8 +82,7 @@ template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildMesh2DMiniTPM(std::string FEType,
                                                      int N,
                                                      int M,
-                                                     int numProcsCoarseSolve,
-                                                     std::string underlyingLib){
+                                                     int numProcsCoarseSolve){
 
     this->FEType_ = FEType;
 
@@ -283,8 +281,7 @@ template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildMesh2D(std::string FEType,
                                                  int N,
                                                  int M,
-                                                 int numProcsCoarseSolve,
-                                                 std::string underlyingLib){
+                                                 int numProcsCoarseSolve){
 
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -622,8 +619,7 @@ template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildMesh3D(std::string FEType,
                                                  int N,
                                                  int M,
-                                                 int numProcsCoarseSolve,
-                                                 std::string underlyingLib){
+                                                 int numProcsCoarseSolve){
 
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -993,15 +989,15 @@ void MeshStructured<SC,LO,GO,NO>::buildMesh3D(std::string FEType,
         buildElementsClass(elementsVec, elementFlag);
     }
     else if(FEType == "P1-disc" || FEType == "P1-disc-global")
-        buildP1_Disc_Q2_3DCube( N, MM, numProcsCoarseSolve, underlyingLib );
+        buildP1_Disc_Q2_3DCube( N, MM, numProcsCoarseSolve );
     else if(FEType == "Q1"){
-        build3DQ1Cube( N, M, numProcsCoarseSolve, underlyingLib );
+        build3DQ1Cube( N, M, numProcsCoarseSolve );
     }
     else if(FEType == "Q2"){
-        build3DQ2Cube( N, MM, numProcsCoarseSolve, underlyingLib );
+        build3DQ2Cube( N, MM, numProcsCoarseSolve );
     }
     else if(FEType == "Q2-20"){
-        build3DQ2_20Cube( N, MM, numProcsCoarseSolve, underlyingLib );
+        build3DQ2_20Cube( N, MM, numProcsCoarseSolve );
     }
 
 
@@ -1011,8 +1007,7 @@ void MeshStructured<SC,LO,GO,NO>::buildMesh3D(std::string FEType,
 template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildP1_Disc_Q2_3DCube(int N,
                                                         int M,
-                                                        int numProcsCoarseSolve,
-                                                        std::string underlyingLib){
+                                                        int numProcsCoarseSolve){
 
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -1192,8 +1187,7 @@ void MeshStructured<SC,LO,GO,NO>::buildP1_Disc_Q2_3DCube(int N,
 template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::build3DQ1Cube(int N,
                                                 int M,
-                                                int numProcsCoarseSolve,
-                                                std::string underlyingLib)
+                                                int numProcsCoarseSolve)
 {
 
     using Teuchos::RCP;
@@ -1316,8 +1310,7 @@ void MeshStructured<SC,LO,GO,NO>::build3DQ1Cube(int N,
 template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::build3DQ2Cube(int N,
                                                 int M,
-                                                int numProcsCoarseSolve,
-                                                std::string underlyingLib)
+                                                int numProcsCoarseSolve)
 {
 
     using Teuchos::RCP;
@@ -1527,8 +1520,7 @@ GO MeshStructured<SC,LO,GO,NO>::globalID_Q2_20Cube(int r, int s , int t, int &rr
 template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::build3DQ2_20Cube(int N,
                                                    int M,
-                                                   int numProcsCoarseSolve,
-                                                   std::string underlyingLib)
+                                                   int numProcsCoarseSolve)
 {
 
     using Teuchos::RCP;
@@ -1677,8 +1669,7 @@ void MeshStructured<SC,LO,GO,NO>::build3DQ2_20Cube(int N,
 template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::build3DQ2BFS(int N,
                                                 int M,
-                                                int numProcsCoarseSolve,
-                                                std::string underlyingLib){
+                                                int numProcsCoarseSolve){
 
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -1875,8 +1866,7 @@ template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildMesh2DBFS(std::string FEType,
                                                     int N,
                                                     int M,
-                                                    int numProcsCoarseSolve,
-                                                    std::string underlyingLib) {
+                                                    int numProcsCoarseSolve) {
 
 
     using Teuchos::RCP;
@@ -2333,8 +2323,7 @@ template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildMesh3DBFS(std::string FEType,
                                                     int N,
                                                     int M,
-                                                    int numProcsCoarseSolve,
-                                                    std::string underlyingLib){
+                                                    int numProcsCoarseSolve){
 
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -2560,7 +2549,7 @@ void MeshStructured<SC,LO,GO,NO>::buildMesh3DBFS(std::string FEType,
         buildElementsClass(elementsVec);
     }
     else if(FEType == "P1-disc" || FEType == "P1-disc-global")
-        buildP1_Disc_Q2_3DBFS( N, MM, numProcsCoarseSolve, underlyingLib );
+        buildP1_Disc_Q2_3DBFS( N, MM, numProcsCoarseSolve );
     else if(FEType == "P2"){
 
         this->pointsRep_.reset(new std::vector<std::vector<double> >(nmbPoints,std::vector<double>(3,0.0)));
@@ -2784,15 +2773,14 @@ void MeshStructured<SC,LO,GO,NO>::buildMesh3DBFS(std::string FEType,
         buildElementsClass(elementsVec);
     }
     else if(FEType == "Q2")
-        build3DQ2BFS( N, MM, numProcsCoarseSolve, underlyingLib );
+        build3DQ2BFS( N, MM, numProcsCoarseSolve);
 
 };
 
 template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildP1_Disc_Q2_3DBFS(int N,
                                                      int M,
-                                                     int numProcsCoarseSolve,
-                                                     std::string underlyingLib){
+                                                     int numProcsCoarseSolve){
 
 
 
@@ -3554,8 +3542,7 @@ template <class SC, class LO, class GO, class NO>
 void MeshStructured<SC,LO,GO,NO>::buildMesh3D5Elements(std::string FEType,
                                                  int N,
                                                  int M,
-                                                 int numProcsCoarseSolve,
-                                                 std::string underlyingLib){
+                                                 int numProcsCoarseSolve){
 
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -4025,7 +4012,6 @@ void MeshStructured<SC,LO,GO,NO>::buildElementMap(){
     for (int i=0; i<elementsGlobalMapping.size(); i++)
         elementsGlobalMapping[i] = i + offset;
 
-    std::string underlyingLib = this->mapRepeated_->getUnderlyingLib();
     this->elementMap_.reset(new Map<LO,GO,NO>(  (GO) -1, elementsGlobalMapping(), 0, this->comm_) );
 
 }

--- a/feddlib/core/Mesh/Mesh_def.hpp
+++ b/feddlib/core/Mesh/Mesh_def.hpp
@@ -301,7 +301,7 @@ void Mesh<SC,LO,GO,NO>::moveMesh( MultiVectorPtr_Type displacementUnique, MultiV
             // und anschliessend mit [] auf den Wert des Arrays.
             // Beachte falls x ein Array ist (also z.B. double *), dann ist x[i] := *(x+i)!!!
             // Liefert also direkt den Wert und keinen Pointer auf einen double.
-            // Achtung: MultiVector[] liefert double* wohingegen MultiVector() Epetra_Vector* zurueck liefert
+            // Achtung: MultiVector[] liefert double* wohingegen MultiVector() Tpetra_Vector* zurueck liefert
             pointsUni_->at(i).at(j) = pointsUniRef_->at(i).at(j) + values[dim_*i+j];
         }
     }

--- a/feddlib/problems/examples/laplaceBlocks/main.cpp
+++ b/feddlib/problems/examples/laplaceBlocks/main.cpp
@@ -67,8 +67,6 @@ int main(int argc, char *argv[]) {
 
     // Command Line Parameters
     Teuchos::CommandLineProcessor myCLP;
-    string ulib_str = "Tpetra";
-    myCLP.setOption("ulib",&ulib_str,"Underlying lib");
 
     string xmlProblemFile = "parametersProblem.xml";
     myCLP.setOption("problemfile",&xmlProblemFile,".xml file with Inputparameters.");

--- a/feddlib/problems/specific/NonLinElasAssFE_def.hpp
+++ b/feddlib/problems/specific/NonLinElasAssFE_def.hpp
@@ -167,7 +167,6 @@ void NonLinElasAssFE<SC,LO,GO,NO>::evalModelImpl(const Thyra::ModelEvaluatorBase
     using Teuchos::ArrayView;
     using Teuchos::Array;
     
-    TEUCHOS_TEST_FOR_EXCEPTION( this->solution_->getBlock(0)->getMap()->getUnderlyingLib() != "Tpetra", std::runtime_error, "Use of NOX only supports Tpetra. Epetra support must be implemented.");
     RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
     TEUCHOS_TEST_FOR_EXCEPTION( inArgs.get_x().is_null(), std::logic_error, "inArgs.get_x() is null.");
     

--- a/feddlib/problems/specific/NonLinElasticity_def.hpp
+++ b/feddlib/problems/specific/NonLinElasticity_def.hpp
@@ -148,7 +148,6 @@ void NonLinElasticity<SC,LO,GO,NO>::evalModelImpl(const Thyra::ModelEvaluatorBas
     using Teuchos::ArrayView;
     using Teuchos::Array;
     
-    TEUCHOS_TEST_FOR_EXCEPTION( this->solution_->getBlock(0)->getMap()->getUnderlyingLib() != "Tpetra", std::runtime_error, "Use of NOX only supports Tpetra. Epetra support must be implemented.");
     RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
     TEUCHOS_TEST_FOR_EXCEPTION( inArgs.get_x().is_null(), std::logic_error, "inArgs.get_x() is null.");
     

--- a/feddlib/problems/specific/NonLinLaplace_def.hpp
+++ b/feddlib/problems/specific/NonLinLaplace_def.hpp
@@ -137,10 +137,6 @@ void NonLinLaplace<SC, LO, GO, NO>::evalModelImpl(
     using Teuchos::rcp_const_cast;
     using Teuchos::rcp_dynamic_cast;
 
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        this->solution_->getBlock(0)->getMap()->getUnderlyingLib() != "Tpetra",
-        std::runtime_error,
-        "Use of NOX only supports Tpetra. Epetra support must be implemented.");
     RCP<Teuchos::FancyOStream> fancy =
         Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
     TEUCHOS_TEST_FOR_EXCEPTION(inArgs.get_x().is_null(), std::logic_error,


### PR DESCRIPTION
Further steps to eliminate the use of the obsolete Epetra package from FEDDLib.