### PR TITLE
Change Doxygen workflow to only trigger in case of merged PRs or direct pushes to develop branch

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,20 +1,25 @@
-# This is a basic workflow to help you get started with Actions
+# Run Doxygen and deploy to GitHub Pages.
 
 name: Doxygen Action
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Events: Control when the action will run. Trigger the workflow on push or 
+# pull request events but only for the develop branch and only if the pull request 
+# is closed. It is further restricted in the build job to only merged PRs.
 on:
   push:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
+    types: [ closed ]
 
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # Restrict to merged PRs if PR is closed. Ignored otherwise.
+    if: github.event.pull_request.merged == true
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -7,7 +7,8 @@ name: Doxygen Action
 on:
   push:
     branches: [ develop ]
-
+  pull_request:
+    branches: [ develop ]
 
   
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
Not tested. Since there is no obvious way to test this in a dry run, we should just go ahead and merge it to see if it fixes the issues of failed workflows.