### PR TITLE
Small fixes for Xpetra --> Tpetra

### DIFF
--- a/feddlib/core/General/BCBuilder_def.hpp
+++ b/feddlib/core/General/BCBuilder_def.hpp
@@ -654,8 +654,6 @@ void BCBuilder<SC,LO,GO,NO>::setSystem(const BlockMatrixPtr_Type &blockMatrix) c
 
                     // To get the correct domain from vecDomain_ we need to know the index of any (in this case the
                     // first) entry that was done with addBC for this block
-                    const auto it = std::find(this->vecBlockID_.begin(), this->vecBlockID_.end(), blockRow);
-                    std::cout << " loc " << loc << " it - something " << it - this->vecBlockID_.begin() << std::endl;
                     auto matrixMap = this->vecDomain_.at(loc)->getMapUnique();
                     // // Use Xpetra::MatrixFactory to build a matrix with known row and column maps
                     auto tpetraMatrix = Teuchos::rcp(new Tpetra::CrsMatrix<SC,LO,GO,NO>(matrixMap->getTpetraMap(), matrixMap->getTpetraMap(), 1)); // Tpetra::MatrixFactory<SC, LO, GO, NO>::Build(matrixMap->getTpetraMap(), matrixMap->getTpetraMap(), 1);

--- a/feddlib/core/LinearAlgebra/MultiVector_decl.hpp
+++ b/feddlib/core/LinearAlgebra/MultiVector_decl.hpp
@@ -96,7 +96,7 @@ public:
     /// @param nmbVectors number of vectors in multivector (seen maybe as different columns)
     MultiVector( MapConstPtr_Type map, UN nmbVectors=1 );
 
-    /// @brief Initialize tpetra multivector based on input multivector. Uses underlying map. !! Probably, this is not a deep copy. Both mv have the same pointer.
+    /// @brief Wrap an existing tpetra multivector. TpetraMVPtrIn is left intact and points to the same Tpetra::MultiVector as this->multiVector_.
     /// @param TpetraMVPtrIn tpetra multivector used to build new multivector 
     MultiVector( TpetraMultiVectorPtr_Type& TpetraMVPtrIn );
 
@@ -107,13 +107,13 @@ public:
     /// @brief Destructor
     ~MultiVector();
 
-
-    /// @brief This will replace *this contents with the rhs input. Updated to deep copy, as this is necessary so both this and rhs would NOT have the same pointer
+    /// @brief Copy assignment operator. This does a deep copy of the rhs into *this. The Xpetra::MultiVector copy
+    /// assignment operator performed a deep copy under the hood e.g. for the Xpetra::TpetraMultiVector assign()
+    /// function see
+    /// https://docs.trilinos.org/dev/packages/xpetra/doc/html/Xpetra__TpetraMultiVector__def_8hpp_source.html#l00577
     /// @param rhs source for copy
     /// @return destination/result of copy
     MultiVector_Type& operator= (const MultiVector_Type& rhs) {
-        //*multiVector_ = *rhs.getTpetraMultiVector(); // old version which worked with xpetra
-        FEDDLIB_NOTIFICATION("MultiVector_decl",rhs.getMap()->getComm()->getRank() == 0, " '=' creating a deep copy of input vector into this.");
         Tpetra::deep_copy<SC,LO,GO,NO>(*multiVector_,*rhs.getTpetraMultiVector()); // (destination, source)
         return *this;
     }

--- a/feddlib/core/LinearAlgebra/MultiVector_def.hpp
+++ b/feddlib/core/LinearAlgebra/MultiVector_def.hpp
@@ -43,11 +43,7 @@ map_(),
 importer_(),
 exporter_()
 {
-    
     map_.reset( new Map_Type( tpetraMVPtrIn->getMap() ) );
-
-    FEDDLIB_WARNING("MultiVector_def", this->getMap()->getComm()->getRank() == 0, " MultiVector(TpetraMultiVectorPtr_Type& tpetraMVPtrIn) -- this is not a deep copy of the contents of the MV.");
-
 }
 
 template <class SC, class LO, class GO, class NO>
@@ -57,8 +53,6 @@ map_(),
 importer_(),
 exporter_()
 {
-    //FEDDLIB_NOTIFICATION("MultiVector_def", mvIn->getMap()->getComm()->getRank() == 0, " MultiVector(MultiVectorConstPtr_Type mvIn) new multivector is created based on the input mv data");
-
     multiVector_ =Teuchos::RCP( new TpetraMultiVector_Type(  mvIn->getMap()->getTpetraMap(), mvIn->getNumVectors() ));
     map_.reset( new Map_Type( *mvIn->getMap() ) );
     for (UN j=0; j<this->getNumVectors(); j++) {
@@ -67,7 +61,6 @@ exporter_()
         for (UN i=0; i<valuesThis.size(); i++)//can this be quicker?
             valuesThis[i] = valuesIn[i];
     }
-
 }
 
 template <class SC, class LO, class GO, class NO>

--- a/feddlib/core/Utils/FEDDUtils.hpp
+++ b/feddlib/core/Utils/FEDDUtils.hpp
@@ -5,7 +5,7 @@
 
 
 #ifndef FEDD_TIMER_START
-#define FEDD_TIMER_START(A,S) Teuchos::RCP<Teuchos::TimeMonitor> A = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(std::string("FEDD") + std::string(S))));
+#define FEDD_TIMER_START(A,S) Teuchos::RCP<Teuchos::TimeMonitor> A = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewCounter(std::string("FEDD: ") + std::string(S))));
 #endif
 
 #ifndef FEDD_TIMER_STOP

--- a/feddlib/problems/specific/NavierStokesAssFE_def.hpp
+++ b/feddlib/problems/specific/NavierStokesAssFE_def.hpp
@@ -204,14 +204,7 @@ void NavierStokesAssFE<SC,LO,GO,NO>::assembleConstantMatrices() const{
         this->getPreconditionerConst()->setPressureMassMatrix( Mpressure );
     }
     if (this->verbose_)
-        std::cout << " Call Reassemble FixedPoint and Newton to allocate the Matrix pattern " << std::endl;
-
-    // this->reAssemble("FixedPoint");
-    this->reAssemble("Newton");
-    
-    if (this->verbose_)
         std::cout << "done -- " << std::endl;
-    
 };
     
 


### PR DESCRIPTION
I integrated the Xpetra -> Tpetra change into my working branches. The following small edits resulted.

+ Removed warnings about deep and shallow copying of FEDD::MultiVector in constructors. These function as expected and the same as the previous Xpetra based versions.

+ Updated FEDD_TIMER_START from the deprecated getNewTimer() to getNewCounter().

+ @LeaSassmannshausen Removed a call to reAssemble("Newton") in NavierStokesAssFE::assembleConstantMatrices(). This resulted in increased runtime due to unnecessary assembly. Is there a reason we should keep this? 