### PR TITLE
Avoid passing a reference to an RCP in FEDD::Map

### DIFF
--- a/feddlib/core/LinearAlgebra/Map_decl.hpp
+++ b/feddlib/core/LinearAlgebra/Map_decl.hpp
@@ -61,7 +61,7 @@ public:
 
     Map();
     
-    Map( const TpetraMapConstPtr_Type& tpetraMatPtrIn );
+    Map( const TpetraMapConstPtr_Type tpetraMatPtrIn );
     
     Map( const Map_Type& mapIn );
     

--- a/feddlib/core/LinearAlgebra/Map_def.hpp
+++ b/feddlib/core/LinearAlgebra/Map_def.hpp
@@ -18,7 +18,7 @@ map_()
 }
 
 template <class LO, class GO, class NO>
-Map<LO,GO,NO>::Map( TpetraMapConstPtrConst_Type& tpetraMapPtrIn ):
+Map<LO,GO,NO>::Map( TpetraMapConstPtrConst_Type tpetraMapPtrIn ):
 map_( tpetraMapPtrIn )
 {
     


### PR DESCRIPTION
Unless the function is supposed to modify the RCP, which is not the case here, passing an RCP by reference defeats the purpose of using an RCP (reference counting). In the worst case this may lead to a segfault if the Tpetra::Map passed in is destroyed while the FEDD::Map is still using it. 