### PR TITLE
Fix installation routine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,5 +46,3 @@ configure_file(${CMAKE_SOURCE_DIR}/FEDDLib_Config.h.in
 
 # Install the generated configuration header
 install(FILES ${CMAKE_BINARY_DIR}/FEDDLib_Config.h DESTINATION include)
-
-DESTINATION share/feddlib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,5 +47,4 @@ configure_file(${CMAKE_SOURCE_DIR}/FEDDLib_Config.h.in
 # Install the generated configuration header
 install(FILES ${CMAKE_BINARY_DIR}/FEDDLib_Config.h DESTINATION include)
 
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/feddlib/debug.areas
 DESTINATION share/feddlib)

--- a/cmake/TPLs/FindTPLTrilinos.cmake
+++ b/cmake/TPLs/FindTPLTrilinos.cmake
@@ -188,8 +188,14 @@ endforeach (TPL)
 message(STATUS "Summary of enabled TPLs: ${TRILINOS_ENABLED_TPLS_LIST}")
 
 # Filling variables needed by the TriBITS system
-set (TPL_Trilinos_INCLUDE_DIRS ${FEDDLib_Trilinos_INCLUDE_DIRS})
-set (TPL_Trilinos_LIBRARY_DIRS Trilinos::all_selected_libs) 
-set (TPL_Trilinos_LIBRARIES Trilinos::all_selected_libs)
+# set (TPL_Trilinos_INCLUDE_DIRS ${FEDDLib_Trilinos_INCLUDE_DIRS})
+# set (TPL_Trilinos_LIBRARY_DIRS Trilinos::all_selected_libs) 
+# set (TPL_Trilinos_LIBRARIES Trilinos::all_selected_libs)
 
+# This generates the TrilinosConfig.cmake file for installation together with FEDDLib libs and headers.
+# Since Trilinos types are exposed direclty in the FEDDLib, Trilinos headers are a compile time dependency.
+# It is possible that the generated TrilinosConfig.cmake file is not complete, as this use-case has not been tested to date [27.11.25]. 
+# In this case the install location of Trilinos would need to be passed to the compiler using -I/path/to/Trilinos/install 
+# or the commented code above needs to be fixed.
+tribits_tpl_find_include_dirs_and_libraries(Trilinos)
 message(STATUS "End of processing Trilinos installation.\n")

--- a/feddlib/core/AceFemAssembly/AceInterface/CMakeLists.txt
+++ b/feddlib/core/AceFemAssembly/AceInterface/CMakeLists.txt
@@ -35,12 +35,6 @@ CACHE INTERNAL "")
 
 set(LOCAL_HEADERS)
 foreach(INC ${AceFemAssemblyAceInterface_HEADERS})
-  string(REPLACE "AceInterface/" "" LOCAL_INC ${INC})
+  string(REPLACE "AceFemAssembly/AceInterface/" "" LOCAL_INC ${INC})
   append_set(LOCAL_HEADERS ${LOCAL_INC})
 endforeach()
-
-install(
-  FILES ${LOCAL_HEADERS}
-  DESTINATION "${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}/feddlib/core/AceFemAssembly/AceInterface"
-  COMPONENT ${PACKAGE_NAME}
-)

--- a/feddlib/core/AceFemAssembly/specific/CMakeLists.txt
+++ b/feddlib/core/AceFemAssembly/specific/CMakeLists.txt
@@ -59,6 +59,6 @@ CACHE INTERNAL "")
 
 set(LOCAL_HEADERS)
 foreach(INC ${AceFemAssemblySpecific_HEADERS})
-  string(REPLACE "specific/" "" LOCAL_INC ${INC})
+  string(REPLACE "AceFemAssembly/specific/" "" LOCAL_INC ${INC})
   append_set(LOCAL_HEADERS ${LOCAL_INC})
 endforeach()


### PR DESCRIPTION
See issue https://github.com/FEDDLib/FEDDLib/issues/32. Currently, if make install is run, an error is thrown. There does not seem to be an easy way to disable installations, except to remove all INSTALL commands.

Thus, this PR attempts to correct the installation routine.

I will correct some paths to fix the error that is thrown. Furthermore, header files are installed twice in the include folder. I will remove the corresponding INSTALL commands that copy files to subfolders of the include folder.