### PR TITLE
Permit explicit instantiation of FEDDLib MultiVector class

### DIFF
--- a/feddlib/core/LinearAlgebra/MultiVector.cpp
+++ b/feddlib/core/LinearAlgebra/MultiVector.cpp
@@ -5,6 +5,7 @@
 #include "MultiVector_def.hpp"
 namespace FEDD {
     template class MultiVector<default_sc, default_lo, default_go, default_no>;
+    template class MultiVector<default_lo, default_lo, default_go, default_no>;
 }
 #endif  // HAVE_EXPLICIT_INSTANTIATION
 #endif


### PR DESCRIPTION
Explicit instantiation of the MultiVector class is currently not possible due to Thyra getters that only support a double scalar type. Since the MultiVector is also used for an integer scalar type, an explicit instantiation cannot generate the code for this; see PR #73 for more details.

I have moved this sub-issue from PR #73 to this PR to address and test it separately.

Support for C++17 and C++20 is included. In the medium term, we should drop the C++17 support, as its implementation is difficult to read.

