### PR TITLE
Pressure projection for Navier Stokes Problem

### DIFF
--- a/feddlib/core/FE/FE_decl.hpp
+++ b/feddlib/core/FE/FE_decl.hpp
@@ -214,6 +214,7 @@ class FE {
                                 MultiVectorPtr_Type solution_rep, 
                                 int FEloc=0);
 
+    void assemblyPressureMeanValue(int dim, std::string FEType, MultiVectorPtr_Type a);
 
     // void assemblyAceGenTPM( MatrixPtr_Type &A00,
     //                         MatrixPtr_Type &A01,
@@ -518,12 +519,6 @@ class FE {
                                            MultiVectorPtr_Type u, // Geschwindigkeit
                                            bool callFillComplete = true);
 
-
-    /// @brief Assembling Pressure Integral to determine pressure mean value
-    /// @param dim Dimension
-    /// @param FEType FEType
-    /// @param a Resultin matrix with one column
-    void assemblyPressureMeanValue(int dim, std::string FEType, MatrixPtr_Type a, MatrixPtr_Type aT);
 
     void assemblyRHS(int dim,
                      std::string FEType,

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -8641,20 +8641,21 @@ void FE<SC,LO,GO,NO>::assemblyRHS( int dim,
     }
 }
 
-/// @brief Assembling \int p \dx = 0. Thus, we need the integral part for the mean pressure value. We need this to be in matrix format, as it is added to the system
+
+
+/// @brief Assembling \int p \dx = 0. Thus, we need the integral part for the mean pressure value. 
 /// @param dim Dimension
 /// @param FEType FEType
 /// @param a Matrix Ptr with resulting assembly
 template <class SC, class LO, class GO, class NO>
 void FE<SC,LO,GO,NO>::assemblyPressureMeanValue( int dim,
                                    std::string FEType,
-                                   MatrixPtr_Type  a,
-                                   MatrixPtr_Type  aT) 
-                                   {
+                                   MultiVectorPtr_Type  a)
+    {
 
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
 
-    TEUCHOS_TEST_FOR_EXCEPTION( a.is_null(), std::runtime_error, "Matrix is null." );
+    TEUCHOS_TEST_FOR_EXCEPTION( a.is_null(), std::runtime_error, "Multivector is null." );
 
     UN FEloc;
     FEloc = checkFE(dim,FEType);
@@ -8663,10 +8664,9 @@ void FE<SC,LO,GO,NO>::assemblyPressureMeanValue( int dim,
 
     vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
     vec2D_dbl_ptr_Type phi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
-    // last parameter should alwayss be the degree
+
     UN deg = 2; 
 
     vec2D_dbl_ptr_Type quadPoints;
@@ -8677,10 +8677,11 @@ void FE<SC,LO,GO,NO>::assemblyPressureMeanValue( int dim,
     SC detB;
     SC absDetB;
     SmallMatrix<SC> B(dim);
-    GO glob_i, glob_j;
-    vec_dbl_Type v_i(dim);
-    vec_dbl_Type v_j(dim);
-  
+   
+    // Repeated version we assemble
+    MultiVectorPtr_Type a_rep = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FEloc)->getMapRepeated(), 1 ) );
+    a_rep->putScalar(0.);
+	Teuchos::ArrayRCP< SC > values_a = a_rep->getDataNonConst(0);
 
     for (UN T=0; T<elements->numberElements(); T++) {
 
@@ -8691,20 +8692,19 @@ void FE<SC,LO,GO,NO>::assemblyPressureMeanValue( int dim,
         for (UN i=0; i < phi->at(0).size(); i++) {
             Teuchos::Array<SC> value( 1, 0. );
             for (UN w=0; w<weights->size(); w++){
-                value[0] += weights->at(w) * phi->at(w).at(i)*1.0;
+                value[0] += weights->at(w) * phi->at(w).at(i)*1.0; // We integrate the 1 function over the elements
             }
             value[0] *= absDetB;
+            //value[0] = 10.;
             LO row = (LO) elements->getElement(T).getNode(i);
-            Teuchos::Array<GO> columnIndices( 1, 0 ); // We only have on column
 
-            a->insertGlobalValues( row, columnIndices(), value() ); // Automatically adds entries if a value already exists 
-            columnIndices[0] = row;
-            aT->insertGlobalValues( 0, columnIndices(), value() ); // Automatically adds entries if a value already exists 
+            values_a[row] += value[0];
         }
     }
-    a->fillComplete();
-    //a->print();
-    
+
+    // Adding it together in the unique vector
+    a->putScalar(0.);
+    a->exportFromVector( a_rep, true, "Add" );  
 }
 
 

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -8695,7 +8695,6 @@ void FE<SC,LO,GO,NO>::assemblyPressureMeanValue( int dim,
                 value[0] += weights->at(w) * phi->at(w).at(i)*1.0; // We integrate the 1 function over the elements
             }
             value[0] *= absDetB;
-            //value[0] = 10.;
             LO row = (LO) elements->getElement(T).getNode(i);
 
             values_a[row] += value[0];

--- a/feddlib/core/LinearAlgebra/BlockMultiVector_decl.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMultiVector_decl.hpp
@@ -139,6 +139,11 @@ public:
 
     MultiVectorConstPtr_Type getMergedVector();
 
+    /// @brief Return the merged vector as non-const vector. This finds application in pressure projection
+    /// @return 
+    MultiVectorPtr_Type getMergedVectorNonConst();
+
+
 private:
 
     Teuchos::Array<MultiVectorPtr_Type> blockMultiVector_;

--- a/feddlib/core/LinearAlgebra/BlockMultiVector_def.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMultiVector_def.hpp
@@ -463,5 +463,16 @@ typename BlockMultiVector<SC,LO,GO,NO>::MultiVectorConstPtr_Type BlockMultiVecto
     else
         return this->getBlockNonConst(0);
 }
+
+template <class SC, class LO, class GO, class NO>
+typename BlockMultiVector<SC,LO,GO,NO>::MultiVectorPtr_Type BlockMultiVector<SC,LO,GO,NO>::getMergedVectorNonConst(){
+    if (this->size()>1) {
+        this->merge();
+        return mergedMultiVector_;
+    }
+    else
+        return this->getBlockNonConst(0);
+}
+
 }
 #endif

--- a/feddlib/problems/Solver/Preconditioner_decl.hpp
+++ b/feddlib/problems/Solver/Preconditioner_decl.hpp
@@ -144,6 +144,14 @@ public:
 
     bool isPreconditionerComputed() const{return precondtionerIsBuilt_;}
 
+    /// @brief Setting pressure projection from specific prolem to be used in preconditioner
+    /// @param pressureProjection 
+    void setPressureProjection(BlockMultiVectorPtr_Type pressureProjection) const;
+
+    /// @brief Getting pressure projection used in preconditioner
+    /// @return pressure projection
+    BlockMultiVectorPtr_Type getPressureProjection(){return pressureProjection_;}
+
 
 private:
     ThyraPrecPtr_Type thyraPrec_;
@@ -185,6 +193,9 @@ private:
     
     mutable MatrixPtr_Type pcdOperatorMatrixPtr_; // PCD
     mutable ThyraLinOpConstPtr_Type pcdOperator_; // PCD
+
+    // Block multivector for pressure projection
+    mutable BlockMultiVectorPtr_Type pressureProjection_;
 
     // For construction in the FEDDLib
     MinPrecProblemPtr_Type probLaplace_;

--- a/feddlib/problems/Solver/Preconditioner_def.hpp
+++ b/feddlib/problems/Solver/Preconditioner_def.hpp
@@ -95,6 +95,11 @@ precFactory_()
 {
     timeProblem_.reset( problem, false );
 
+    // We need to ensure that already set information is upheld
+    if(!problem->getUnderlyingProblem()->preconditioner_->getPressureProjection().is_null()){
+        setPressureProjection(problem->getUnderlyingProblem()->preconditioner_->getPressureProjection());
+    }
+
     if(!problem->getUnderlyingProblem()->preconditioner_->getVelocityMassMatrix().is_null()){
         setVelocityMassMatrix(problem->getUnderlyingProblem()->preconditioner_->getVelocityMassMatrix());
     }
@@ -151,6 +156,11 @@ void Preconditioner<SC,LO,GO,NO>::initializePreconditioner( std::string type )
     }
     else
         TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Unkown preconditioner type for initialization.");
+}
+
+template <class SC,class LO,class GO,class NO>
+void Preconditioner<SC,LO,GO,NO>::setPressureProjection(BlockMultiVectorPtr_Type pressureProjection) const{
+    pressureProjection_ = pressureProjection;
 }
 
 template <class SC,class LO,class GO,class NO>
@@ -451,6 +461,21 @@ void Preconditioner<SC,LO,GO,NO>::buildPreconditionerMonolithic( )
             pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").set("DofOrdering Vector",dofOrderings);
             pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").set("DofsPerNode Vector",dofsPerNodeVector);
             pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").set( "Mpi Ranks Coarse",parameterList->sublist("General").get("Mpi Ranks Coarse",0) );
+
+            // This a pressure projection is only used for saddle point problems. We check here if we have a pressure projection set and if we have more than one block or one block with dim dof per node (i.e. fluid problem)
+            // This is unfortunately called pressure correction in FROSch, but is a projection!
+            if(!pressureProjection_.is_null() && ( dofsPerNodeVector.size() > 1 || dofsPerNodeVector[0] == 1) ){
+                pressureProjection_->merge(); // We merge the projection vector, as FROSch does not distinguish between blocks
+
+                Teuchos::RCP< Tpetra::MultiVector<SC,LO,GO,NO> > vectorTpetra =  pressureProjection_->getMergedVectorNonConst()->getTpetraMultiVectorNonConst();
+                Teuchos::RCP< Xpetra::TpetraMultiVector<SC,LO,GO,NO> > vectorXpetraTpetra = Teuchos::rcp(new Xpetra::TpetraMultiVector<SC,LO,GO,NO>(vectorTpetra));
+                Teuchos::RCP< Xpetra::MultiVector<SC,LO,GO,NO> > vectorXpetra = Teuchos::rcp_dynamic_cast<Xpetra::MultiVector<SC,LO,GO,NO>>(vectorXpetraTpetra);
+
+                pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").sublist("AlgebraicOverlappingOperator").set("Projection",vectorXpetra);
+                // In case of pressure correction we set the parameter in the paramterlist to true
+                pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").sublist("AlgebraicOverlappingOperator").set("Use Pressure Correction", true);
+                pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").sublist("AlgebraicOverlappingOperator").set("Use Local Pressure Correction", true);
+            }
 
             /*  We need to set the ranges of local problems and the coarse problem here.
                 When using an unstructured decomposition of, e.g., FSI, with 2 domains, which might be on a different set of ranks, we need to set the following parameters for FROSch here. Similarly we need to set a coarse rank problem range. For now, we use extra coarse ranks only for structured decompositions

--- a/feddlib/problems/Solver/Preconditioner_def.hpp
+++ b/feddlib/problems/Solver/Preconditioner_def.hpp
@@ -472,7 +472,7 @@ void Preconditioner<SC,LO,GO,NO>::buildPreconditionerMonolithic( )
                 Teuchos::RCP< Xpetra::MultiVector<SC,LO,GO,NO> > vectorXpetra = Teuchos::rcp_dynamic_cast<Xpetra::MultiVector<SC,LO,GO,NO>>(vectorXpetraTpetra);
 
                 pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").sublist("AlgebraicOverlappingOperator").set("Projection",vectorXpetra);
-                // In case of pressure correction we set the parameter in the paramterlist to true
+                // In case of pressure correction we set the parameter in the parameterlist to true
                 pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").sublist("AlgebraicOverlappingOperator").set("Use Pressure Correction", true);
                 pListThyraPrec->sublist("Preconditioner Types").sublist("FROSch").sublist("AlgebraicOverlappingOperator").set("Use Local Pressure Correction", true);
             }

--- a/feddlib/problems/examples/steadyNavierStokes/main.cpp
+++ b/feddlib/problems/examples/steadyNavierStokes/main.cpp
@@ -396,7 +396,7 @@ int main(int argc, char *argv[]) {
                         bcFactory->addBC(ldcFunc3D, 2, 0, domainVelocity, "Dirichlet", dim,parameter_vec); // Lid
                         bcFactory->addBC(zeroDirichlet, 3, 1, domainPressure, "Dirichlet", 1); // Pressure Node
                         if(parameterListAll->sublist("Parameter").get("Use Pressure Projection",false)==true && linearization=="NOX")
-                            std::cout << " WARNING: 'Use Pressure Projection' is set to true. This does not work for the LDC test with NOX. Somehow the Dirichlet fixed pressure point at (0,0,0) is an issue.Remove the RB to make it work or choose Newton!" << std::endl;
+                            std::cout << " WARNING: 'Use Pressure Projection' is set to true. This does not work for the LDC test with NOX. Somehow the Dirichlet fixed pressure point at (0,0,0) is an issue. Remove the RB to make it work or choose Newton!" << std::endl;
                     }
                        
                 }

--- a/feddlib/problems/examples/steadyNavierStokes/main.cpp
+++ b/feddlib/problems/examples/steadyNavierStokes/main.cpp
@@ -387,12 +387,16 @@ int main(int argc, char *argv[]) {
                         bcFactory->addBC(zeroDirichlet2D, 1, 0, domainVelocity, "Dirichlet", dim); // wall
                         bcFactory->addBC(ldcFunc2D, 2, 0, domainVelocity, "Dirichlet", dim,parameter_vec); // lid
                         bcFactory->addBC(zeroDirichlet, 3, 1, domainPressure, "Dirichlet", 1); // pressure node
+                        if(parameterListAll->sublist("Parameter").get("Use Pressure Projection",false)==true && linearization=="NOX")
+                            std::cout << " WARNING: 'Use Pressure Projection' is set to true. This does not work for the LDC test with NOX. Somehow the Dirichlet fixed pressure point at (0,0,0) is an issue. Remove the RB to make it work or choose Newton!" << std::endl;
 
                     }
                     else if (dim==3){
                         bcFactory->addBC(zeroDirichlet3D, 1, 0, domainVelocity, "Dirichlet", dim); // Wall
                         bcFactory->addBC(ldcFunc3D, 2, 0, domainVelocity, "Dirichlet", dim,parameter_vec); // Lid
                         bcFactory->addBC(zeroDirichlet, 3, 1, domainPressure, "Dirichlet", 1); // Pressure Node
+                        if(parameterListAll->sublist("Parameter").get("Use Pressure Projection",false)==true && linearization=="NOX")
+                            std::cout << " WARNING: 'Use Pressure Projection' is set to true. This does not work for the LDC test with NOX. Somehow the Dirichlet fixed pressure point at (0,0,0) is an issue.Remove the RB to make it work or choose Newton!" << std::endl;
                     }
                        
                 }

--- a/feddlib/problems/examples/steadyNavierStokes/parametersProblem.xml
+++ b/feddlib/problems/examples/steadyNavierStokes/parametersProblem.xml
@@ -26,6 +26,10 @@
         <!-- Testing Residuals, Or means either abolute or relative tolerance is achieved -->
         <Parameter name="Combo" type="string" value="OR"/>
         <Parameter name="Use WRMS" type="bool" value="false"/>
+
+        <!-- use pressure projection to correct pressure in P2-P1/Q2-Q1 case-->
+        <Parameter name="Use Pressure Projection" type="bool" value="false"/>   
+
     </ParameterList>
     <ParameterList name="General">
 		<!-- Linearization method-->

--- a/feddlib/problems/examples/unsteadyNavierStokes/parametersProblem.xml
+++ b/feddlib/problems/examples/unsteadyNavierStokes/parametersProblem.xml
@@ -28,6 +28,9 @@
         <Parameter name="MaxNonLinIts" type="int" value="10"/>
         <Parameter name="Cancel MaxNonLinIts" type="bool" value="true"/>
         <Parameter name="Symmetric gradient" type="bool" value="false"/>
+
+        <!-- use pressure projection to correct pressure in P2-P1/Q2-Q1 case-->
+        <Parameter name="Use Pressure Projection" type="bool" value="false"/>   
     </ParameterList>
     <ParameterList name="Mesh Partitioner">
         

--- a/feddlib/problems/examples/unsteadyNavierStokes/parametersSolver.xml
+++ b/feddlib/problems/examples/unsteadyNavierStokes/parametersSolver.xml
@@ -4,26 +4,26 @@
         <Parameter name="Linear Solver Type" type="string" value="Belos"/>
         <ParameterList name="Linear Solver Types">
             <ParameterList name="Belos">
+                <Parameter name="Left Preconditioner If Unspecified" type="bool" value="false"/>
                 <Parameter name="Solver Type" type="string" value="Block GMRES"/>
                 <ParameterList name="Solver Types">
                     <ParameterList name="Block GMRES">
+                        <Parameter name="Convergence Tolerance" type="double" value="1e-4"/> <!-- If NOX is not used, this is the tolerance that is followed-->
+                        <Parameter name="Maximum Iterations" type="int" value="1000"/>
+                        <Parameter name="Num Blocks" type="int" value="1000"/> <!-- number of search directions before restart-->
                         <Parameter name="Block Size" type="int" value="1"/>
-                        <Parameter name="Convergence Tolerance" type="double" value="1e-6"/>
-                        <Parameter name="Maximum Iterations" type="int" value="100"/>
                         <Parameter name="Output Frequency" type="int" value="1"/>
+                        <!--<Parameter name="Verbosity" type="int" value="1"/>-->
                         <Parameter name="Show Maximum Residual Norm Only" type="bool" value="1"/>
                     </ParameterList>
                 </ParameterList>
+                <ParameterList name="VerboseObject">
+                        <Parameter name="Verbosity Level" type="string" value="medium"/>
+                </ParameterList>
             </ParameterList>
-            
-            <ParameterList name="Amesos2">
-                <Parameter name="Solver Type" type="string"   value="MUMPS"/>
-            </ParameterList>
-            
         </ParameterList>
-    
     </ParameterList>
-    
+
     <ParameterList name="NOXSolver">
         <Parameter name="Nonlinear Solver" type="string" value="Line Search Based"/>
         <ParameterList name="Direction">
@@ -31,20 +31,26 @@
                 <Parameter name="Forcing Term Method" type="string" value="Constant"/> <!-- Constant, Type 1, Type 2-->
                 <Parameter name="Forcing Term Initial Tolerance" type="double" value="1.e-3"/>
                 <Parameter name="Forcing Term Minimum Tolerance" type="double" value="1.e-8"/>
-                <Parameter name="Forcing Term Maximum Tolerance" type="double" value="0.01"/>
+                <Parameter name="Forcing Term Maximum Tolerance" type="double" value="1.e-3"/>
+                <!-- <Parameter name="Forcing Term Alpha" type="double" value="1."/>
+                <Parameter name="Forcing Term Gamma" type="double" value="1."/>-->
+                <Parameter name="Rescue Bad Newton Solve" type="bool" value="true"/>
                 <ParameterList name="Linear Solver">
-                    <Parameter name="Tolerance" type="double" value="1e-6"/>
+                    <Parameter name="Tolerance" type="double" value="1e-4"/> <!-- Value in case of Constant forcing term-->
                 </ParameterList>
             </ParameterList>
         </ParameterList>
+        <ParameterList name="Line Search">
+            <Parameter name="Method" type="string" value="Backtrack"/><!-- Backtrack, More'-Thuente-->
+        </ParameterList>
         <ParameterList name="Printing">
             <ParameterList name="Output Information">
-                <Parameter name="Debug" type="bool" value="false"/>
-                <Parameter name="Warning" type="bool" value="false"/>
-                <Parameter name="Error" type="bool" value="false"/>
-                <Parameter name="Test Details" type="bool" value="false"/>
+                <Parameter name="Debug" type="bool" value="true"/>
+                <Parameter name="Warning" type="bool" value="true"/>
+                <Parameter name="Error" type="bool" value="true"/>
+                <Parameter name="Test Details" type="bool" value="true"/>
                 <Parameter name="Details" type="bool" value="true"/>
-                <Parameter name="Parameters" type="bool" value="false"/>
+                <Parameter name="Parameters" type="bool" value="true"/>
                 <Parameter name="Linear Solver Details" type="bool" value="true"/>
                 <Parameter name="Inner Iteration" type="bool" value="true"/>
                 <Parameter name="Outer Iteration" type="bool" value="true"/>

--- a/feddlib/problems/specific/NavierStokes_decl.hpp
+++ b/feddlib/problems/specific/NavierStokes_decl.hpp
@@ -36,6 +36,7 @@ public:
     typedef typename Problem_Type::MultiVectorPtr_Type MultiVectorPtr_Type;
     typedef typename Problem_Type::MultiVectorConstPtr_Type MultiVectorConstPtr_Type;
     typedef typename Problem_Type::BlockMultiVectorPtr_Type BlockMultiVectorPtr_Type;
+    typedef typename Problem_Type::BlockMultiVector_Type BlockMultiVector_Type;
 
     typedef typename Problem_Type::Domain_Type Domain_Type;
     typedef typename Problem_Type::DomainPtr_Type DomainPtr_Type;

--- a/feddlib/problems/specific/NavierStokes_def.hpp
+++ b/feddlib/problems/specific/NavierStokes_def.hpp
@@ -235,7 +235,7 @@ void NavierStokes<SC,LO,GO,NO>::assembleConstantMatrices() const{
         this->getPreconditionerConst()->setPressureProjection( projection );    
 
         if (this->verbose_)
-            std::cout << "\n 'Use pressure correction' was set to 'true'. This requieres a version of Trilinos of that includes pressure correction in the FROSch_OverlappingOperator!!" << std::endl;  
+            std::cout << "\n 'Use pressure correction' was set to 'true'. This requires a version of Trilinos that includes pressure correction in the FROSch_OverlappingOperator!!" << std::endl;  
 
     }
 

--- a/feddlib/problems/specific/NavierStokes_def.hpp
+++ b/feddlib/problems/specific/NavierStokes_def.hpp
@@ -231,7 +231,7 @@ void NavierStokes<SC,LO,GO,NO>::assembleConstantMatrices() const{
         projection->addBlock(vel0,0);
         projection->addBlock(P,1);
 
-        // Setting projection vector in preconditioner to later pass to paramterlist in FROSch
+        // Setting projection vector in preconditioner to later pass to parameterlist in FROSch
         this->getPreconditionerConst()->setPressureProjection( projection );    
 
         if (this->verbose_)

--- a/feddlib/problems/specific/NavierStokes_def.hpp
+++ b/feddlib/problems/specific/NavierStokes_def.hpp
@@ -213,6 +213,31 @@ void NavierStokes<SC,LO,GO,NO>::assembleConstantMatrices() const{
     this->system_->addBlock( A_, 0, 0 );
     assembleDivAndStab();
     
+    // If pressure projection is used, we need to assemble the projection vector here
+    // Only for P2-P1 or Q2-Q1 elements in monolithic case
+    if(this->parameterList_->sublist("Parameter").get("Use Pressure Projection",false) && (!this->getFEType(0).compare("P2") || (!this->getFEType(0).compare("Q2") && !this->getFEType(1).compare("Q1"))) && !this->parameterList_->sublist("General").get("Preconditioner Method","Monolithic").compare("Monolithic")){ 
+        // Projection vector a: \int p dx, for pressure component and 0 for velocity.
+        BlockMultiVectorPtr_Type projection(new BlockMultiVector_Type (2));
+
+        MultiVectorPtr_Type P(new MultiVector_Type( this->getDomain(1)->getMapUnique(), 1 ) );
+
+        this->feFactory_->assemblyPressureMeanValue( this->dim_,this->getFEType(1),P) ;
+
+        // Velocity component is set to zero, such that the projection vector only influences the pressure part
+        MultiVectorPtr_Type vel0(new MultiVector_Type( this->getDomain(0)->getMapVecFieldUnique(), 1 ) );
+        vel0->putScalar(0.);
+
+        // Adding components to projection vector 
+        projection->addBlock(vel0,0);
+        projection->addBlock(P,1);
+
+        // Setting projection vector in preconditioner to later pass to paramterlist in FROSch
+        this->getPreconditionerConst()->setPressureProjection( projection );    
+
+        if (this->verbose_)
+            std::cout << "\n 'Use pressure correction' was set to 'true'. This requieres a version of Trilinos of that includes pressure correction in the FROSch_OverlappingOperator!!" << std::endl;  
+
+    }
 
 #ifdef FEDD_HAVE_TEKO
     if ( !this->parameterList_->sublist("General").get("Preconditioner Method","Monolithic").compare("Teko") 


### PR DESCRIPTION
Pressure projection option is added to FEDDLib. This option is only working with corresponding Trilinos Branch!

Parameter added in Parameterlist:
        <!-- use pressure projection to correct pressure in P2-P1/Q2-Q1 case-->
        <Parameter name="Use Pressure Projection" type="bool" value="true"/>   

**!! In previous versions the parameter was called _Use Pressure Correction_ - It is now called _Use Pressure Projection_ in the FEDDLib !!** 

All tests passed on Amandus

We noticed one issue: The combination of Lid-Driven Cavity problem with NOX and pressure projection left GMRES unconverged. The problem seems to be the (0,0) Dirichlet pressure point. Removing it, resolved the issue. Also using Newton instead of NOX fixed the issue. There seems to be something odd going on with NOX and that pressure Dirichlet point and Pressure Projection.