### PR TITLE
Resolve forced circular dependency of FSI class with TimeProblem class

### DIFF
--- a/feddlib/problems/abstract/NonLinearProblem_decl.hpp
+++ b/feddlib/problems/abstract/NonLinearProblem_decl.hpp
@@ -17,6 +17,9 @@
 namespace FEDD{
 template<class SC_, class LO_, class GO_, class NO_>
 class Problem;
+template<class SC_, class LO_, class GO_, class NO_>
+class TimeProblem;
+
 template <class SC = default_sc,
           class LO = default_lo,
           class GO = default_go,
@@ -121,7 +124,7 @@ public:
     virtual void calculateNonLinResidualVec(std::string type="standard", double time=0.) const = 0; //type=standard or reverse
 
     /// @brief Calculate the non-linear residual vector with given coefficients for time-dependent problems (if used for timeproblem)
-    virtual void calculateNonLinResidualVec(SmallMatrix<double>& coeff, std::string type="standard", double time=0.); //type=standard or reverse
+    virtual void calculateNonLinResidualVec(SmallMatrix<double>& coeff, std::string type="standard", double time=0., BlockMatrixPtr_Type systemMass = Teuchos::null); //type=standard or reverse
     
     /// @brief Get the residual vector
     /// @return residual vector

--- a/feddlib/problems/abstract/NonLinearProblem_def.hpp
+++ b/feddlib/problems/abstract/NonLinearProblem_def.hpp
@@ -1,6 +1,7 @@
 #ifndef NONLINEARPROBLEM_DEF_hpp
 #define NONLINEARPROBLEM_DEF_hpp
 #include "NonLinearProblem_decl.hpp"
+#include "TimeProblem.hpp"
 
 /*!
  Definition of NonLinearProblem
@@ -97,7 +98,7 @@ namespace FEDD
     }
 
     template <class SC, class LO, class GO, class NO>
-    void NonLinearProblem<SC, LO, GO, NO>::calculateNonLinResidualVec(SmallMatrix<double> &coeff, std::string type, double time)
+    void NonLinearProblem<SC, LO, GO, NO>::calculateNonLinResidualVec(SmallMatrix<double> &coeff, std::string type, double time, BlockMatrixPtr_Type systemMass)
     {
 
         coeff_ = coeff;

--- a/feddlib/problems/abstract/TimeProblem_decl.hpp
+++ b/feddlib/problems/abstract/TimeProblem_decl.hpp
@@ -181,15 +181,15 @@ public:
     BlockMultiVectorPtrArray_Type getSolutionAllPreviousTimestep();
 
     BlockMatrixPtr_Type getMassSystem();
-    
+
     ParameterListPtr_Type getParameterList();
-        
+
     void assembleSourceTerm( double time=0. );
 
     BlockMultiVectorPtr_Type getSourceTerm( );
-        
+
     bool hasSourceTerm() const;
-    
+
     CommConstPtr_Type getComm() const{return  comm_;}
 
     LinSolverBuilderPtr_Type getLinearSolverBuilder() const;
@@ -197,20 +197,20 @@ public:
     void getValuesOfInterest( vec_dbl_Type& values );
 
     void computeValuesOfInterestAndExport();
-    
+
     void updateTime( double time ){ time_ = time;}
 
     void addToRhs(BlockMultiVectorPtr_Type x);
-    
+
     ProblemPtr_Type problem_;
     CommConstPtr_Type comm_;
-    
+
     mutable BlockMatrixPtr_Type systemCombined_;
     mutable BlockMatrixPtr_Type systemMass_;
     mutable SmallMatrix<double> timeParameters_;
     SmallMatrix<int>        timeStepDef_;
     SmallMatrix<double>     massParameters_;
-    
+
     FEFacPtr_Type feFactory_;
 //    bool					boolLinearProblem_;
     int                     dimension_;

--- a/feddlib/problems/abstract/TimeProblem_def.hpp
+++ b/feddlib/problems/abstract/TimeProblem_def.hpp
@@ -439,21 +439,9 @@ void TimeProblem<SC,LO,GO,NO>::calculateNonLinResidualVec( std::string type, dou
     else{
         // rhs and sourceterm is accounted for in calculateNonLinResidualVec.
         // rhs must bet assembled (computed) correctly in DAESolver (e.g. M/dt*u_t). sourceterm aswell
-        nonLinProb->calculateNonLinResidualVec( timeParameters_ ,type, time );
-
         // for FSI we need to reassemble the massmatrix system if the mesh was moved for geometry implicit computations
-        if (this->parameterList_->sublist("Parameter").get("FSI",false) ){
-            bool geometryExplicit = this->parameterList_->sublist("Parameter").get("Geometry Explicit",true);
-            if( !geometryExplicit ) {
-                typedef FSI<SC,LO,GO,NO> FSI_Type;
-                typedef Teuchos::RCP<FSI_Type> FSIPtr_Type;
-                
-                MatrixPtr_Type massmatrix;                
-                FSIPtr_Type fsi = Teuchos::rcp_dynamic_cast<FSI_Type>( this->problem_ );
-                fsi->setFluidMassmatrix( massmatrix );
-                this->systemMass_->addBlock( massmatrix, 0, 0 );
-            }
-        }
+        nonLinProb->calculateNonLinResidualVec( timeParameters_ ,type, time, this->systemMass_ );
+
         // we need to add M/dt*u_(t+1)^k (the last results of the nonlinear method) to the residualVec_
         //Copy
         BlockMultiVectorPtr_Type tmpMV = Teuchos::rcp(new BlockMultiVector_Type( nonLinProb->getSolution() ) );

--- a/feddlib/problems/specific/FSI_decl.hpp
+++ b/feddlib/problems/specific/FSI_decl.hpp
@@ -20,6 +20,7 @@ template <class SC , class LO , class GO , class NO >
 class LinElas;
 template <class SC , class LO , class GO , class NO >
 class NonLinElasticity;
+
 template <class SC = default_sc, class LO = default_lo, class GO = default_go, class NO = default_no>
 class FSI : public NonLinearProblem<SC,LO,GO,NO>  {
 
@@ -117,7 +118,10 @@ public:
     
     virtual void reAssembleExtrapolation(BlockMultiVectorPtrArray_Type previousSolutions);
 
-    virtual void calculateNonLinResidualVec(std::string type="standard", double time=0.) const; //standard or reverse    
+    virtual void calculateNonLinResidualVec(std::string type="standard", double time=0.) const override; //standard or reverse
+
+    /// @brief Calculate the non-linear residual vector with given coefficients for time-dependent problems (if used for timeproblem)
+    void calculateNonLinResidualVec(SmallMatrix<double>& coeff, std::string type="standard", double time=0., BlockMatrixPtr_Type systemMass = Teuchos::null) override; //type=standard or reverse
     
     virtual void getValuesOfInterest( vec_dbl_Type& values );
     

--- a/feddlib/problems/specific/FSI_def.hpp
+++ b/feddlib/problems/specific/FSI_def.hpp
@@ -836,6 +836,20 @@ void FSI<SC,LO,GO,NO>::calculateNonLinResidualVec(std::string type, double time)
 
 }
 
+template <class SC, class LO, class GO, class NO>
+void FSI<SC, LO, GO, NO>::calculateNonLinResidualVec(SmallMatrix<double> &coeff, std::string type, double time, BlockMatrixPtr_Type systemMass)
+{
+    NonLinearProblem<SC,LO,GO,NO>::calculateNonLinResidualVec(coeff,type,time);
+
+    // for FSI we need to reassemble the massmatrix system if the mesh was moved for geometry implicit computations
+    bool geometryExplicit = this->parameterList_->sublist("Parameter").get("Geometry Explicit",true);
+    if( !geometryExplicit ) {
+        MatrixPtr_Type massmatrix;
+        this->setFluidMassmatrix( massmatrix );
+        systemMass->addBlock( massmatrix, 0, 0 );
+    }
+}
+
 // Muss derzeit nur am Anfang jeder Zeititeration aufgerufen werden, damit
 // problemTimeFluid_ und problemTimeStructure_ die aktuelle Loesung haben.
 // ACHTUNG: Wenn wir irgendwann einmal anfangen reAssemble() auf problemFluid_ und


### PR DESCRIPTION
FSI code is inside the TimeProblem class, such that the TimeProblem class depends on the FSI class. Since FSI itself also depends on TimeProblem, we have a circular dependency. We can get rid of it by leveraging polymorphism. The structure is already in place and only a small piece of code needs to be moved from the TimeProblem to the FSI class.

This change does not yet resolve the circular dependency itself, since that comes from the inclusion of header files in different classes, but it allows the resolution when the inclusion of header files is revised. This will probably be done with PR #73. The current PR is necessary to advance in PR #73.