### PR TITLE
Revise header inclusions

### DIFF
--- a/feddlib/amr/AdaptiveMeshRefinement.cpp
+++ b/feddlib/amr/AdaptiveMeshRefinement.cpp
@@ -1,6 +1,5 @@
-#include "AdaptiveMeshRefinement_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AdaptiveMeshRefinement_decl.hpp"
 #include "AdaptiveMeshRefinement_def.hpp"
 namespace FEDD {
     template class AdaptiveMeshRefinement<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/amr/AdaptiveMeshRefinement.hpp
+++ b/feddlib/amr/AdaptiveMeshRefinement.hpp
@@ -1,8 +1,8 @@
 #ifndef AdaptiveMeshRefinement_hpp
 #define AdaptiveMeshRefinement_hpp
 #include "AdaptiveMeshRefinement_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "RefinementFactory_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AdaptiveMeshRefinement_def.hpp"
+#endif
 
 #endif

--- a/feddlib/amr/AdaptiveMeshRefinement_decl.hpp
+++ b/feddlib/amr/AdaptiveMeshRefinement_decl.hpp
@@ -1,6 +1,9 @@
 #ifndef AdaptiveMeshRefinement_decl_hpp
 #define AdaptiveMeshRefinement_decl_hpp
 
+#include <Tpetra_CrsMatrix.hpp>
+#include <boost/function.hpp>
+
 #include "feddlib/core/Utils/FEDDUtils.hpp"
 #include "feddlib/core/Mesh/Mesh.hpp"
 #include "feddlib/core/Mesh/MeshUnstructured.hpp"
@@ -10,14 +13,14 @@
 #include "feddlib/core/FE/TriangleElements.hpp"
 #include "feddlib/core/FE/EdgeElements.hpp"
 #include "feddlib/core/FE/Domain.hpp"
-#include <Tpetra_CrsMatrix.hpp>
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/Mesh/MeshStructured.hpp"
 #include "feddlib/core/Mesh/MeshUnstructured.hpp"
 #include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
-#include  <boost/function.hpp>
+#include "feddlib/core/General/ExporterTxt.hpp"
+
 #include "feddlib/problems/abstract/Problem.hpp"
+
 #include "feddlib/amr/ExporterParaViewAMR.hpp"
 #include "feddlib/amr/ErrorEstimation.hpp"
 #include "feddlib/amr/RefinementFactory.hpp"

--- a/feddlib/amr/AdaptiveMeshRefinement_def.hpp
+++ b/feddlib/amr/AdaptiveMeshRefinement_def.hpp
@@ -9,7 +9,6 @@
 #define MESH_TIMER_STOP(A) A.reset();
 #endif
 
-#include "AdaptiveMeshRefinement_decl.hpp"
 #include <chrono> 
 #include <iomanip>
 /*!

--- a/feddlib/amr/ErrorEstimation.cpp
+++ b/feddlib/amr/ErrorEstimation.cpp
@@ -1,6 +1,5 @@
-#include "ErrorEstimation_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "ErrorEstimation_decl.hpp"
 #include "ErrorEstimation_def.hpp"
 namespace FEDD {
     template class ErrorEstimation<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/amr/ErrorEstimation.hpp
+++ b/feddlib/amr/ErrorEstimation.hpp
@@ -1,8 +1,8 @@
 #ifndef ErrorEstimation_hpp
 #define ErrorEstimation_hpp
 #include "ErrorEstimation_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "RefinementFactory_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "ErrorEstimation_def.hpp"
+#endif
 
 #endif

--- a/feddlib/amr/ErrorEstimation_def.hpp
+++ b/feddlib/amr/ErrorEstimation_def.hpp
@@ -9,8 +9,7 @@
 #define MESH_TIMER_STOP(A) A.reset();
 #endif
 
-#include "ErrorEstimation_decl.hpp"
-#include "feddlib/core/LinearAlgebra/MultiVector_def.hpp"
+#include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include <chrono> 
 /*!
  Definition of ErrorEstimation

--- a/feddlib/amr/ExporterParaViewAMR.cpp
+++ b/feddlib/amr/ExporterParaViewAMR.cpp
@@ -1,6 +1,5 @@
-#include "ExporterParaViewAMR_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "ExporterParaViewAMR_decl.hpp"
 #include "ExporterParaViewAMR_def.hpp"
 namespace FEDD {
 template class ExporterParaViewAMR<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/amr/ExporterParaViewAMR.hpp
+++ b/feddlib/amr/ExporterParaViewAMR.hpp
@@ -2,8 +2,8 @@
 #define ExporterParaViewAMR_hpp
 
 #include "ExporterParaViewAMR_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "ExporterParaViewAMR_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "ExporterParaViewAMR_def.hpp"
+#endif
 
 #endif // PRECONDMANAGERFORSCH_hpp

--- a/feddlib/amr/ExporterParaViewAMR_def.hpp
+++ b/feddlib/amr/ExporterParaViewAMR_def.hpp
@@ -1,8 +1,6 @@
 #ifndef ExporterParaViewAMR_def_hpp
 #define ExporterParaViewAMR_def_hpp
 
-#include "ExporterParaViewAMR_decl.hpp"
-
 /*!
  Definition of ExporterParaView
 

--- a/feddlib/amr/RefinementFactory.cpp
+++ b/feddlib/amr/RefinementFactory.cpp
@@ -1,6 +1,5 @@
-#include "RefinementFactory_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "RefinementFactory_decl.hpp"
 #include "RefinementFactory_def.hpp"
 namespace FEDD {
     template class RefinementFactory<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/amr/RefinementFactory.hpp
+++ b/feddlib/amr/RefinementFactory.hpp
@@ -1,8 +1,8 @@
 #ifndef RefinementFactory_hpp
 #define RefinementFactory_hpp
 #include "RefinementFactory_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "RefinementFactory_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "RefinementFactory_def.hpp"
+#endif
 
 #endif

--- a/feddlib/amr/RefinementFactory_def.hpp
+++ b/feddlib/amr/RefinementFactory_def.hpp
@@ -9,8 +9,7 @@
 #define MESH_TIMER_STOP(A) A.reset();
 #endif
 
-#include "RefinementFactory_decl.hpp"
-#include "feddlib/core/LinearAlgebra/MultiVector_def.hpp"
+#include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include <chrono> 
 /*!
  Definition of RefinementFactory

--- a/feddlib/amr/tests/laplaceAdaptive/main.cpp
+++ b/feddlib/amr/tests/laplaceAdaptive/main.cpp
@@ -6,8 +6,13 @@
 #define MAIN_TIMER_STOP(A) A.reset();
 #endif
 
+#include <Tpetra_Core.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <boost/function.hpp>
+#include <chrono> 
+
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/FE/FiniteElement.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
@@ -17,19 +22,12 @@
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/problems/specific/Laplace.hpp"
 #include "feddlib/problems/abstract/Problem.hpp"
-#include <Teuchos_GlobalMPISession.hpp>
 #include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
 #include "feddlib/core/LinearAlgebra/BlockMultiVector.hpp"
 #include "feddlib/core/Mesh/Mesh.hpp"
 #include "feddlib/core/Mesh/MeshInterface.hpp"
 #include "feddlib/core/Mesh/MeshFileReader.hpp"
 #include "feddlib/amr/AdaptiveMeshRefinement.hpp"
-#include <Tpetra_Core.hpp>
-
-
-#include <boost/function.hpp>
-#include <chrono> 
-
 
 /*!
  main of Laplace problem

--- a/feddlib/amr/tests/steadyNavierStokesAdaptive/main.cpp
+++ b/feddlib/amr/tests/steadyNavierStokesAdaptive/main.cpp
@@ -6,12 +6,10 @@
 #define MAIN_TIMER_STOP(A) A.reset();
 #endif
 
-#include "feddlib/amr/AdaptiveMeshRefinement.hpp"
-
 #include <Teuchos_TestForException.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
 
-#include "feddlib/problems/abstract/Problem.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/FE/Domain.hpp"
@@ -19,10 +17,12 @@
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 
+#include "feddlib/problems/abstract/Problem.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
 #include "feddlib/problems/specific/NavierStokes.hpp"
 
-#include <Teuchos_GlobalMPISession.hpp>
+#include "feddlib/amr/AdaptiveMeshRefinement.hpp"
+
 
 /*!
  main of Stokes problem

--- a/feddlib/amr/tests/steadyNonLinElasAssFE/main.cpp
+++ b/feddlib/amr/tests/steadyNonLinElasAssFE/main.cpp
@@ -1,18 +1,16 @@
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include <Tpetra_Core.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
 
+#include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/problems/specific/LinElas.hpp"
 #include "feddlib/problems/specific/NonLinElasticity.hpp"
-#include <Teuchos_GlobalMPISession.hpp>
-
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
 #include "feddlib/amr/AdaptiveMeshRefinement.hpp"
-
-#include <Tpetra_Core.hpp>
 
 
 void zeroDirichlet(double* x, double* res, double t, const double* parameters)

--- a/feddlib/amr/tests/stokesAdaptive/main.cpp
+++ b/feddlib/amr/tests/stokesAdaptive/main.cpp
@@ -6,21 +6,19 @@
 #define MAIN_TIMER_STOP(A) A.reset();
 #endif
 
+#include <Teuchos_TestForException.hpp>
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Tpetra_Core.hpp>
+
 #include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 
 #include "feddlib/problems/specific/Stokes.hpp"
 #include "feddlib/amr/AdaptiveMeshRefinement.hpp"
-
-#include <Teuchos_TestForException.hpp>
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_Core.hpp>
-
 #include "feddlib/problems/abstract/Problem.hpp"
 
 /*!

--- a/feddlib/amr/tests/unsteadyReactionDiffusion/main.cpp
+++ b/feddlib/amr/tests/unsteadyReactionDiffusion/main.cpp
@@ -1,12 +1,12 @@
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include <Teuchos_GlobalMPISession.hpp>
 
+#include "feddlib/core/FEDDCore.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/problems/specific/DiffusionReaction.hpp"
-#include <Teuchos_GlobalMPISession.hpp>
 #include "feddlib/problems/Solver/DAESolverInTime.hpp"
 #include "feddlib/amr/AdaptiveMeshRefinement.hpp"
 

--- a/feddlib/core/AceFemAssembly/AssembleFE.cpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFE_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFE_decl.hpp"
 #include "AssembleFE_def.hpp"
 namespace FEDD {
     template class AssembleFE<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/AssembleFE.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE.hpp
@@ -1,7 +1,7 @@
 #ifndef ASSEMBLEFE_hpp
 #define ASSEMBLEFE_hpp
 #include "AssembleFE_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "AssembleFE_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFE_def.hpp"
+#endif
 #endif 

--- a/feddlib/core/AceFemAssembly/AssembleFEBlock.cpp
+++ b/feddlib/core/AceFemAssembly/AssembleFEBlock.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFEBlock_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFEBlock_decl.hpp"
 #include "AssembleFEBlock_def.hpp"
 namespace FEDD {
     template class AssembleFEBlock<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/AssembleFEBlock.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFEBlock.hpp
@@ -1,7 +1,7 @@
 #ifndef ASSEMBLEFEBLOCK_hpp
 #define ASSEMBLEFEBLOCK_hpp
 #include "AssembleFEBlock_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "AssembleFE_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFEBlock_def.hpp"
+#endif
 #endif 

--- a/feddlib/core/AceFemAssembly/AssembleFEBlock_decl.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFEBlock_decl.hpp
@@ -1,4 +1,3 @@
-
 #ifndef AssembleFEBlock_DECL_hpp
 #define AssembleFEBlock_DECL_hpp
 

--- a/feddlib/core/AceFemAssembly/AssembleFEBlock_def.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFEBlock_def.hpp
@@ -1,8 +1,6 @@
 #ifndef AssembleFEBLOCK_DEF_hpp
 #define AssembleFEBLOCK_DEF_hpp
 
-#include "AssembleFEBlock_decl.hpp"
-
 namespace FEDD {
 
 

--- a/feddlib/core/AceFemAssembly/AssembleFEFactory.cpp
+++ b/feddlib/core/AceFemAssembly/AssembleFEFactory.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFEFactory_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFEFactory_decl.hpp"
 #include "AssembleFEFactory_def.hpp"
 namespace FEDD {
     template class AssembleFEFactory<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/AssembleFEFactory.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFEFactory.hpp
@@ -1,8 +1,8 @@
 #ifndef ASSEMBLEFEFACTORY_hpp
 #define ASSEMBLEFEFACTORY_hpp
 #include "AssembleFEFactory_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "AssembleFEFactory_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFEFactory_def.hpp"
+#endif
 
 #endif 

--- a/feddlib/core/AceFemAssembly/AssembleFEFactory_decl.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFEFactory_decl.hpp
@@ -1,7 +1,6 @@
 #ifndef ASSEMBLEFEFACTORY_DECL_hpp
 #define ASSEMBLEFEFACTORY_DECL_hpp
 
-
 #include "feddlib/core/AceFemAssembly/AssembleFE.hpp"
 #include "feddlib/core/AceFemAssembly/AssembleFEBlock.hpp"
 #include "feddlib/core/FEDDCore.hpp"
@@ -12,9 +11,9 @@
 #include "feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2.hpp"
 #include "feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes.hpp"
 #include "feddlib/core/AceFemAssembly/specific/AssembleFEGeneralizedNewtonian.hpp"
-#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH_decl.hpp"
-#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK_decl.hpp"
-#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp"
+#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH.hpp"
+#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK.hpp"
+#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation.hpp"
 
 namespace FEDD {
 

--- a/feddlib/core/AceFemAssembly/AssembleFEFactory_def.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFEFactory_def.hpp
@@ -1,8 +1,6 @@
 #ifndef ASSEMBLEFEFACTORY_DEF_hpp
 #define ASSEMBLEFEFACTORY_DEF_hpp
 
-#include "AssembleFEFactory_decl.hpp"
-
 namespace FEDD {
 
 

--- a/feddlib/core/AceFemAssembly/AssembleFE_def.hpp
+++ b/feddlib/core/AceFemAssembly/AssembleFE_def.hpp
@@ -1,8 +1,6 @@
 #ifndef ASSEMBLEFE_DEF_hpp
 #define ASSEMBLEFE_DEF_hpp
 
-#include "AssembleFE_decl.hpp"
-
 namespace FEDD {
 
 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFEGeneralizedNewtonian.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFEGeneralizedNewtonian.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFEGeneralizedNewtonian_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFEGeneralizedNewtonian_decl.hpp"
 #include "AssembleFEGeneralizedNewtonian_def.hpp"
 namespace FEDD {
     template class AssembleFEGeneralizedNewtonian<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFEGeneralizedNewtonian.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFEGeneralizedNewtonian.hpp
@@ -1,8 +1,8 @@
 #ifndef AssembleFEGeneralizedNewtonian_hpp
 #define AssembleFEGeneralizedNewtonian_hpp
 #include "AssembleFEGeneralizedNewtonian_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "AssembleFEGeneralizedNewtonian_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFEGeneralizedNewtonian_def.hpp"
+#endif
 
-#endif // MATRIX_hpp
+#endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFEGeneralizedNewtonian_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFEGeneralizedNewtonian_def.hpp
@@ -1,8 +1,6 @@
 #ifndef AssembleFEGeneralizedNewtonian_DEF_hpp
 #define AssembleFEGeneralizedNewtonian_DEF_hpp
 
-#include "AssembleFENavierStokes_decl.hpp"
-
 namespace FEDD
 {
     // All important things are so far defined in AssembleFENavierStokes. Please check there.

--- a/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFENavierStokes_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFENavierStokes_decl.hpp"
 #include "AssembleFENavierStokes_def.hpp"
 namespace FEDD {
     template class AssembleFENavierStokes<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes.hpp
@@ -1,8 +1,8 @@
 #ifndef ASSEMBLEFENAVIERSTOKES_hpp
 #define ASSEMBLEFENAVIERSTOKES_hpp
 #include "AssembleFENavierStokes_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "AssembleFEAceNavierStokes_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFENavierStokes_def.hpp"
+#endif
 
-#endif // MATRIX_hpp
+#endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes_def.hpp
@@ -1,8 +1,6 @@
 #ifndef ASSEMBLEFENAVIERSTOKES_DEF_hpp
 #define ASSEMBLEFENAVIERSTOKES_DEF_hpp
 
-#include "AssembleFENavierStokes_decl.hpp"
-
 namespace FEDD {
 
 template <class SC, class LO, class GO, class NO>

--- a/feddlib/core/AceFemAssembly/specific/AssembleFENonLinLaplace.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENonLinLaplace.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFENonLinLaplace_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFENonLinLaplace_decl.hpp"
 #include "AssembleFENonLinLaplace_def.hpp"
 namespace FEDD {
 template class AssembleFENonLinLaplace<default_sc, default_lo, default_go,

--- a/feddlib/core/AceFemAssembly/specific/AssembleFENonLinLaplace.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENonLinLaplace.hpp
@@ -1,8 +1,8 @@
 #ifndef ASSEMBLEFENONLINLAPLACE_hpp
 #define ASSEMBLEFENONLINLAPLACE_hpp
 #include "AssembleFENonLinLaplace_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "AssembleFELaplace_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFENonLinLaplace_def.hpp"
+#endif
 
 #endif // ASSEMBLEFENONLINLAPLACE_hpp

--- a/feddlib/core/AceFemAssembly/specific/AssembleFENonLinLaplace_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFENonLinLaplace_def.hpp
@@ -1,7 +1,6 @@
 #ifndef ASSEMBLEFENONLINLAPLACE_DEF_hpp
 #define ASSEMBLEFENONLINLAPLACE_DEF_hpp
 
-#include "AssembleFENonLinLaplace_decl.hpp"
 #include "feddlib/core/FEDDCore.hpp"
 #include <Teuchos_Array.hpp>
 #include <Teuchos_ScalarTraitsDecl.hpp>

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_Laplace.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_Laplace.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFE_Laplace_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFE_Laplace_decl.hpp"
 #include "AssembleFE_Laplace_def.hpp"
 namespace FEDD {
     template class AssembleFE_Laplace<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_Laplace.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_Laplace.hpp
@@ -1,8 +1,8 @@
 #ifndef ASSEMBLEFE_LAPLACE_hpp
 #define ASSEMBLEFE_LAPLACE_hpp
 #include "AssembleFE_Laplace_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "AssembleFE_Laplace_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFE_Laplace_def.hpp"
+#endif
 
-#endif // MATRIX_hpp
+#endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_Laplace_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_Laplace_def.hpp
@@ -1,8 +1,6 @@
 #ifndef ASSEMBLEFE_LAPLACE_DEF_hpp
 #define ASSEMBLEFE_LAPLACE_DEF_hpp
 
-#include "AssembleFE_Laplace_decl.hpp"
-
 namespace FEDD {
 
 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_LinElas.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_LinElas.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFE_LinElas_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFE_LinElas_decl.hpp"
 #include "AssembleFE_LinElas_def.hpp"
 namespace FEDD {
     template class AssembleFE_LinElas<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_LinElas.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_LinElas.hpp
@@ -1,6 +1,9 @@
 #ifndef ASSEMBLEFE_LINELAS_hpp
 #define ASSEMBLEFE_LINELAS_hpp
+
 #include "AssembleFE_LinElas_decl.hpp"
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFE_LinElas_def.hpp"
+#endif
 
-
-#endif // ASSEMBLEFELINELAS_hpp
+#endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_LinElas_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_LinElas_def.hpp
@@ -1,7 +1,6 @@
 #ifndef ASSEMBLEFE_LINELAS_DEF_hpp
 #define ASSEMBLEFE_LINELAS_DEF_hpp
 
-#include "AssembleFE_LinElas_decl.hpp"
 #include "feddlib/core/AceFemAssembly/AceInterface/NeoHookQuadraticTets.hpp"
 #include <vector>
 #include <iostream>

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFE_NonLinElas_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFE_NonLinElas_decl.hpp"
 #include "AssembleFE_NonLinElas_def.hpp"
 namespace FEDD {
     template class AssembleFE_NonLinElas<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas.hpp
@@ -1,6 +1,8 @@
 #ifndef ASSEMBLEFE_NONLINELAS_hpp
 #define ASSEMBLEFE_NONLINELAS_hpp
 #include "AssembleFE_NonLinElas_decl.hpp"
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFE_NonLinElas_def.hpp"
+#endif
 
-
-#endif // ASSEMBLEFELINELAS_hpp
+#endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFE_NonLinElas2_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFE_NonLinElas2_decl.hpp"
 #include "AssembleFE_NonLinElas2_def.hpp"
 namespace FEDD {
     template class AssembleFE_NonLinElas2<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2.hpp
@@ -1,6 +1,7 @@
 #ifndef ASSEMBLEFE_NONLINELAS2_hpp
 #define ASSEMBLEFE_NONLINELAS2_hpp
 #include "AssembleFE_NonLinElas2_decl.hpp"
-
-
-#endif // ASSEMBLEFELINELAS_hpp
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFE_NonLinElas2_def.hpp"
+#endif
+#endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas2_def.hpp
@@ -1,7 +1,6 @@
 #ifndef  AssembleFE_NonLinElas2_DEF_hpp
 #define  AssembleFE_NonLinElas2_DEF_hpp
 
-#include "AssembleFE_NonLinElas2_decl.hpp"
 #include "feddlib/core/AceFemAssembly/AceInterface/NeoHookQuadraticTets3.hpp"
 #include <vector>
 #include <iostream>

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_NonLinElas_def.hpp
@@ -1,7 +1,6 @@
 #ifndef ASSEMBLEFE_NONLINELAS_DEF_hpp
 #define ASSEMBLEFE_NONLINELAS_DEF_hpp
 
-#include "AssembleFE_NonLinElas_decl.hpp"
 #include "feddlib/core/AceFemAssembly/AceInterface/NeoHookQuadraticTets2.hpp"
 #include <vector>
 #include <iostream>

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFE_SCI_NH_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFE_SCI_NH_decl.hpp"
 #include "AssembleFE_SCI_NH_def.hpp"
 namespace FEDD {
     template class AssembleFE_SCI_NH<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH.hpp
@@ -1,6 +1,7 @@
 #ifndef ASSEMBLEFE_SCI_NH_hpp
 #define ASSEMBLEFE_SCI_NH_hpp
 #include "AssembleFE_SCI_NH_decl.hpp"
-
-
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFE_SCI_NH_def.hpp"
+#endif
 #endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_NH_def.hpp
@@ -1,7 +1,6 @@
 #ifndef ASSEMBLEFE_SCI_NH_DEF_hpp
 #define ASSEMBLEFE_SCI_NH_DEF_hpp
 
-#include "AssembleFE_SCI_NH_decl.hpp"
 #ifdef FEDD_HAVE_ACEGENINTERFACE
 #include <aceinterface.hpp>
 #endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp"
 #include "AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp"
 namespace FEDD {
     template class AssembleFE_SCI_SMC_Active_Growth_Reorientation<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation.hpp
@@ -1,6 +1,7 @@
 #ifndef ASSEMBLEFE_SCI_SMC_Active_Growth_Reorientation_hpp
 #define ASSEMBLEFE_SCI_SMC_Active_Growth_Reorientation_hpp
 #include "AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp"
-
-
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp"
+#endif
 #endif 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_def.hpp
@@ -1,8 +1,6 @@
 #ifndef AssembleFE_SCI_SMC_Active_Growth_Reorientation_DEF_hpp
 #define AssembleFE_SCI_SMC_Active_Growth_Reorientation_DEF_hpp
 
-#include "AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp"
-
 #ifdef FEDD_HAVE_ACEGENINTERFACE
 #include <aceinterface.hpp>
 #endif

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK.cpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK.cpp
@@ -1,6 +1,5 @@
-#include "AssembleFE_SCI_SMC_MLCK_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AssembleFE_SCI_SMC_MLCK_decl.hpp"
 #include "AssembleFE_SCI_SMC_MLCK_def.hpp"
 namespace FEDD {
     template class AssembleFE_SCI_SMC_MLCK<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK.hpp
@@ -1,6 +1,7 @@
 #ifndef ASSEMBLEFE_SCI_SMC_MLCK_hpp
 #define ASSEMBLEFE_SCI_SMC_MLCK_hpp
 #include "AssembleFE_SCI_SMC_MLCK_decl.hpp"
-
-
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AssembleFE_SCI_SMC_MLCK_def.hpp"
+#endif
 #endif 

--- a/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_MLCK_def.hpp
@@ -1,8 +1,6 @@
 #ifndef AssembleFE_SCI_SMC_MLCK_DEF_hpp
 #define AssembleFE_SCI_SMC_MLCK_DEF_hpp
 
-#include "AssembleFE_SCI_SMC_MLCK_decl.hpp"
-
 #ifdef FEDD_HAVE_ACEGENINTERFACE
 #include <aceinterface.hpp>
 #endif

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/CarreauYasuda.cpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/CarreauYasuda.cpp
@@ -1,6 +1,5 @@
-#include "CarreauYasuda_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "CarreauYasuda_decl.hpp"
 #include "CarreauYasuda_def.hpp"
 namespace FEDD {
     template class CarreauYasuda<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/CarreauYasuda.hpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/CarreauYasuda.hpp
@@ -1,8 +1,7 @@
 #ifndef CARREAUYASUDA_hpp
 #define CARREAUYASUDA_hpp
 #include "CarreauYasuda_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "CarreauYasuda_def.hpp"
-// #endif
-
-#endif //
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "CarreauYasuda_def.hpp"
+#endif
+#endif

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/CarreauYasuda_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/CarreauYasuda_def.hpp
@@ -1,8 +1,6 @@
 #ifndef CARREAUYASUDA_DEF_hpp
 #define CARREAUYASUDA_DEF_hpp
 
-#include "CarreauYasuda_decl.hpp"
-
 namespace FEDD
 {
 

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/Dimless_Carreau.cpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/Dimless_Carreau.cpp
@@ -1,6 +1,5 @@
-#include "Dimless_Carreau_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Dimless_Carreau_decl.hpp"
 #include "Dimless_Carreau_def.hpp"
 namespace FEDD {
     template class Dimless_Carreau<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/Dimless_Carreau.hpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/Dimless_Carreau.hpp
@@ -1,8 +1,8 @@
 #ifndef DIMLESS_CARREAU_hpp
 #define DIMLESS_CARREAU_hpp
 #include "Dimless_Carreau_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "Dimless_Carreau_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Dimless_Carreau_def.hpp"
+#endif
 
 #endif //

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/Dimless_Carreau_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/Dimless_Carreau_def.hpp
@@ -1,8 +1,6 @@
 #ifndef DIMLESS_CARREAU_DEF_hpp
 #define DIMLESS_CARREAU_DEF_hpp
 
-#include "Dimless_Carreau_decl.hpp"
-
 namespace FEDD {
 
 template <class SC, class LO, class GO, class NO>

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/PowerLaw.cpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/PowerLaw.cpp
@@ -1,6 +1,5 @@
-#include "PowerLaw_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "PowerLaw_decl.hpp"
 #include "PowerLaw_def.hpp"
 namespace FEDD {
     template class PowerLaw<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/PowerLaw.hpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/PowerLaw.hpp
@@ -1,8 +1,8 @@
 #ifndef POWERLAW_hpp
 #define POWERLAW_hpp
 #include "PowerLaw_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "PowerLaw_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "PowerLaw_def.hpp"
+#endif
 
-#endif //
+#endif

--- a/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/PowerLaw_def.hpp
+++ b/feddlib/core/AceFemAssembly/specific/GeneralizedNewtonianModels/PowerLaw_def.hpp
@@ -1,8 +1,6 @@
 #ifndef POWERLAW_DEF_hpp
 #define POWERLAW_DEF_hpp
 
-#include "PowerLaw_decl.hpp"
-
 namespace FEDD {
 
 template <class SC, class LO, class GO, class NO>

--- a/feddlib/core/FE/Domain.cpp
+++ b/feddlib/core/FE/Domain.cpp
@@ -1,6 +1,5 @@
-#include "Domain_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Domain_decl.hpp"
 #include "Domain_def.hpp"
 namespace FEDD {
     template class Domain<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/FE/Domain.hpp
+++ b/feddlib/core/FE/Domain.hpp
@@ -1,8 +1,9 @@
 #ifndef Domain_hpp
 #define Domain_hpp
-#include "Domain_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "Domain_def.hpp"
-// #endif
 
-#endif //
+#include "Domain_decl.hpp"
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Domain_def.hpp"
+#endif
+
+#endif

--- a/feddlib/core/FE/Domain_def.hpp
+++ b/feddlib/core/FE/Domain_def.hpp
@@ -1,6 +1,5 @@
 #ifndef Domain_def_hpp
 #define Domain_def_hpp
-#include "Domain_decl.hpp"
 
 /*!
  Definition of Domain

--- a/feddlib/core/FE/Elements.hpp
+++ b/feddlib/core/FE/Elements.hpp
@@ -4,6 +4,7 @@
 #include "feddlib/core/Utils/FEDDUtils.hpp"
 #include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/LinearAlgebra/Map.hpp"
+#include "feddlib/core/General/SmallMatrix.hpp"
 #include "FiniteElement.hpp"
 #include <Teuchos_RCPDecl.hpp>
 #include <Teuchos_RCPBoostSharedPtrConversions.hpp>

--- a/feddlib/core/FE/FE.cpp
+++ b/feddlib/core/FE/FE.cpp
@@ -1,6 +1,5 @@
-#include "FE_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "FE_decl.hpp"
 #include "FE_def.hpp"
 namespace FEDD {
     template class FE<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/FE/FE.hpp
+++ b/feddlib/core/FE/FE.hpp
@@ -1,8 +1,8 @@
 #ifndef FE_hpp
 #define FE_hpp
 #include "FE_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "FE_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "FE_def.hpp"
+#endif
 
 #endif // MATRIX_hpp

--- a/feddlib/core/FE/FE_decl.hpp
+++ b/feddlib/core/FE/FE_decl.hpp
@@ -12,8 +12,8 @@
 #include "Helper.hpp"
 #include "sms.hpp"
 #include "feddlib/core/AceFemAssembly/AssembleFE.hpp"
-#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation_decl.hpp"
-#include "feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes_decl.hpp"
+#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation.hpp"
+#include "feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes.hpp"
 
 #include "feddlib/core/AceFemAssembly/AssembleFEFactory.hpp"
 

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -7,8 +7,6 @@
 #include <aceinterface.hpp>
 #endif
 
-#include "FE_decl.hpp"
-
 /*!
  Definition of FE
 

--- a/feddlib/core/FE/tests/surfaceIntegral.cpp
+++ b/feddlib/core/FE/tests/surfaceIntegral.cpp
@@ -2,6 +2,7 @@
 #include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/problems/abstract/Problem.hpp"
+#include "feddlib/core/FE/FE.hpp"
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Tpetra_Core.hpp>
 

--- a/feddlib/core/FEDDCore.hpp
+++ b/feddlib/core/FEDDCore.hpp
@@ -15,9 +15,7 @@
 #include <limits>
 #include <chrono> 
 
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-#include "feddlib/core/core_config.h"
-#include "feddlib/core/General/SmallMatrix.hpp"
+#include <boost/function.hpp>
 
 #include <Teuchos_RCPDecl.hpp>
 #include <Teuchos_RCPBoostSharedPtrConversions.hpp>
@@ -26,7 +24,17 @@
 #include <Teuchos_TimeMonitor.hpp>
 #include <Teuchos_CommandLineProcessor.hpp>
 
-#include <boost/function.hpp>
+#include <Thyra_LinearOpBase_decl.hpp>
+#include <Thyra_VectorSpaceBase_decl.hpp>
+#include <Thyra_VectorBase.hpp>
+
+#include <Tpetra_CrsMatrix.hpp>
+#include <Tpetra_Operator.hpp>
+
+#include "feddlib/core/core_config.h"
+#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include "feddlib/core/General/SmallMatrix.hpp"
+
 namespace FEDD {
 //    template<class SC, class LO, class GO, class NO>
 //    class InterfaceEntity;
@@ -127,7 +135,20 @@ typedef boost::function<double(double* x, int* parameters)>                     
 typedef boost::function<double(double* x, double* parameters)>                          CoeffFuncDbl_Type;
 typedef boost::function<void(double* x, double* res, double* parameters)>               RhsFunc_Type;
 typedef boost::function<void(double* x, double* res, double t, double* parameters)>     GeneralFunc_Type;        
-typedef boost::function<void(double* x, double* res)>     								Func_Type;          
-    
+typedef boost::function<void(double* x, double* res)>                                   Func_Type;
+
+template <typename SC>
+struct ThyraTypedefs {
+using ThyraOp_Type = Thyra::LinearOpBase<SC>;
+using ThyraVecSpace_Type = Thyra::VectorSpaceBase<SC>;
+using ThyraVec_Type = Thyra::VectorBase<SC>;
+};
+
+template <typename SC, typename LO, typename GO, typename NO>
+struct TpetraTypedefs {
+using TpetraMatrix_Type = Tpetra::CrsMatrix<SC, LO, GO, NO>;
+using TpetraOp_Type = Tpetra::Operator<SC, LO, GO, NO>;
+};
+
 }
 #endif

--- a/feddlib/core/General/BCBuilder.cpp
+++ b/feddlib/core/General/BCBuilder.cpp
@@ -1,6 +1,5 @@
-#include "BCBuilder_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "BCBuilder_decl.hpp"
 #include "BCBuilder_def.hpp"
 namespace FEDD {
 template class BCBuilder<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/General/BCBuilder.hpp
+++ b/feddlib/core/General/BCBuilder.hpp
@@ -2,8 +2,8 @@
 #define BCBuilder_hpp
 
 #include "BCBuilder_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "BCBuilder_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "BCBuilder_def.hpp"
+#endif
 
-#endif // PRECONDMANAGERFORSCH_hpp
+#endif

--- a/feddlib/core/General/BCBuilder_def.hpp
+++ b/feddlib/core/General/BCBuilder_def.hpp
@@ -1,11 +1,10 @@
 #ifndef BCBuilder_def_hpp
 #define BCBuilder_def_hpp
 
-#include "BCBuilder_decl.hpp"
 #include "feddlib/core/Utils/FEDDUtils.hpp"
 #include <Teuchos_RCPDecl.hpp>
 #include <Teuchos_ScalarTraitsDecl.hpp>
-#include <Xpetra_MatrixFactory.hpp>
+
 
 void dummyFuncBC(double* x, double* res, double t, const double* parameters)
 {

--- a/feddlib/core/General/DifferentiableFuncClass.cpp
+++ b/feddlib/core/General/DifferentiableFuncClass.cpp
@@ -1,6 +1,5 @@
-#include "DifferentiableFuncClass_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "DifferentiableFuncClass_decl.hpp"
 #include "DifferentiableFuncClass_def.hpp"
 namespace FEDD {
     template class DifferentiableFuncClass<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/General/DifferentiableFuncClass.hpp
+++ b/feddlib/core/General/DifferentiableFuncClass.hpp
@@ -1,7 +1,7 @@
 #ifndef DIFFERENTIABLEFUNCCLASS_hpp
 #define DIFFERENTIABLEFUNCCLASS_hpp
 #include "DifferentiableFuncClass_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "DIFFERENTIABLEFUNCCLASS_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "DifferentiableFuncClass_def.hpp"
+#endif
 #endif 

--- a/feddlib/core/General/DifferentiableFuncClass_def.hpp
+++ b/feddlib/core/General/DifferentiableFuncClass_def.hpp
@@ -1,8 +1,6 @@
 #ifndef DIFFERENTIABLEFUNCCLASS_DEF_hpp
 #define DIFFERENTIABLEFUNCCLASS_DEF_hpp
 
-#include "DifferentiableFuncClass_decl.hpp"
-
 namespace FEDD {
 
 

--- a/feddlib/core/General/ExporterParaView.cpp
+++ b/feddlib/core/General/ExporterParaView.cpp
@@ -1,6 +1,5 @@
-#include "ExporterParaView_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "ExporterParaView_decl.hpp"
 #include "ExporterParaView_def.hpp"
 namespace FEDD {
 template class ExporterParaView<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/General/ExporterParaView.hpp
+++ b/feddlib/core/General/ExporterParaView.hpp
@@ -2,8 +2,8 @@
 #define ExporterParaView_hpp
 
 #include "ExporterParaView_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "ExporterParaView_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "ExporterParaView_def.hpp"
+#endif
 
-#endif // PRECONDMANAGERFORSCH_hpp
+#endif

--- a/feddlib/core/General/ExporterParaView_decl.hpp
+++ b/feddlib/core/General/ExporterParaView_decl.hpp
@@ -9,8 +9,9 @@
 // Trilinos
 #include <Teuchos_Array.hpp>
 
-#include "HDF5Toolbox_decl.hpp"
 #include <hdf5.h>
+#include "feddlib/core/General/HDF5Toolbox.hpp"
+
 
 /*!
  Declaration of ExporterParaView

--- a/feddlib/core/General/ExporterParaView_def.hpp
+++ b/feddlib/core/General/ExporterParaView_def.hpp
@@ -1,8 +1,6 @@
 #ifndef ExporterParaView_DEF_hpp
 #define ExporterParaView_DEF_hpp
 
-#include "ExporterParaView_decl.hpp"
-
 /*!
  Definition of ExporterParaView
 

--- a/feddlib/core/General/HDF5Export.cpp
+++ b/feddlib/core/General/HDF5Export.cpp
@@ -1,6 +1,5 @@
-#include "HDF5Export_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "HDF5Export_decl.hpp"
 #include "HDF5Export_def.hpp"
 namespace FEDD {
 template class HDF5Export<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/General/HDF5Export.hpp
+++ b/feddlib/core/General/HDF5Export.hpp
@@ -2,8 +2,8 @@
 #define HDF5EXPORT_hpp
 
 #include "HDF5Export_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "HDF5_Export_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "HDF5Export_def.hpp"
+#endif
 
-#endif // PRECONDMANAGERFORSCH_hpp
+#endif

--- a/feddlib/core/General/HDF5Export_def.hpp
+++ b/feddlib/core/General/HDF5Export_def.hpp
@@ -1,9 +1,6 @@
 #ifndef HDF5EXPORT_DEF_hpp
 #define HDF5EXPORT_DEF_hpp
 
-#include "HDF5Export_decl.hpp"
-
-
 namespace FEDD {
  
 template<class SC,class LO,class GO,class NO>

--- a/feddlib/core/General/HDF5Import.cpp
+++ b/feddlib/core/General/HDF5Import.cpp
@@ -1,6 +1,5 @@
-#include "HDF5Import_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "HDF5Import_decl.hpp"
 #include "HDF5Import_def.hpp"
 namespace FEDD {
 template class HDF5Import<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/General/HDF5Import.hpp
+++ b/feddlib/core/General/HDF5Import.hpp
@@ -2,8 +2,8 @@
 #define HDF5IMPORT_hpp
 
 #include "HDF5Import_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "ExporterParaView_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "HDF5Import_def.hpp"
+#endif
 
-#endif // PRECONDMANAGERFORSCH_hpp
+#endif

--- a/feddlib/core/General/HDF5Import_def.hpp
+++ b/feddlib/core/General/HDF5Import_def.hpp
@@ -1,8 +1,6 @@
 #ifndef HDF5IMPORT_DEF_hpp
 #define HDF5IMPORT_DEF_hpp
 
-#include "HDF5Import_decl.hpp"
-
 /*!
  Importing a HDF5 file
 

--- a/feddlib/core/General/HDF5Toolbox.cpp
+++ b/feddlib/core/General/HDF5Toolbox.cpp
@@ -1,6 +1,5 @@
-#include "HDF5Toolbox_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "HDF5Toolbox_decl.hpp"
 #include "HDF5Toolbox_def.hpp"
 namespace FEDD {
 template class HDF5Toolbox<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/General/HDF5Toolbox.hpp
+++ b/feddlib/core/General/HDF5Toolbox.hpp
@@ -1,10 +1,9 @@
 #ifndef HDF5TOOLBOX_hpp
 #define HDF5TOOLBOX_hpp
 
-
 #include "HDF5Toolbox_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "HDF5_Export_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "HDF5Toolbox_def.hpp"
+#endif
 
-#endif // 
+#endif

--- a/feddlib/core/General/HDF5Toolbox_decl.hpp
+++ b/feddlib/core/General/HDF5Toolbox_decl.hpp
@@ -1,12 +1,13 @@
-#ifndef HDF5TOOLBOX_hpp
-#define HDF5TOOLBOX_hpp
+#ifndef HDF5TOOLBOX_DECL_hpp
+#define HDF5TOOLBOX_DECL_hpp
 
-#include "hdf5.h"
-#include "H5FDmpio.h"
+#include <hdf5.h>
+#include <H5FDmpio.h>
+
 #include <Tpetra_Core.hpp>
 #include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
-#include "feddlib/core/LinearAlgebra/Map_decl.hpp"
+#include "feddlib/core/LinearAlgebra/Map.hpp"
 
 /*!
  Declaration of HDF5Toolbox

--- a/feddlib/core/General/HDF5Toolbox_def.hpp
+++ b/feddlib/core/General/HDF5Toolbox_def.hpp
@@ -1,8 +1,6 @@
 #ifndef HDF5TOOLBOX_DEF_hpp
 #define HDF5TOOLBOX_DEF_hpp
 
-#include "HDF5Toolbox_decl.hpp"
-
 /*
   
 

--- a/feddlib/core/General/InputToOutputMappingClass.cpp
+++ b/feddlib/core/General/InputToOutputMappingClass.cpp
@@ -1,6 +1,5 @@
-#include "InputToOutputMappingClass_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "InputToOutputMappingClass_decl.hpp"
 #include "InputToOutputMappingClass_def.hpp"
 namespace FEDD {
     template class InputToOutputMappingClass<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/General/InputToOutputMappingClass.hpp
+++ b/feddlib/core/General/InputToOutputMappingClass.hpp
@@ -1,7 +1,7 @@
 #ifndef InputToOutputMappingClass_hpp
 #define InputToOutputMappingClass_hpp
 #include "InputToOutputMappingClass_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "DIFFERENTIABLEFUNCCLASS_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "InputToOutputMappingClass_def.hpp"
+#endif
 #endif 

--- a/feddlib/core/General/InputToOutputMappingClass_def.hpp
+++ b/feddlib/core/General/InputToOutputMappingClass_def.hpp
@@ -1,8 +1,6 @@
 #ifndef InputToOutputMappingClass_DEF_hpp
 #define InputToOutputMappingClass_DEF_hpp
 
-#include "InputToOutputMappingClass_decl.hpp"
-
 namespace FEDD {
 
 

--- a/feddlib/core/General/SmallMatrix.hpp
+++ b/feddlib/core/General/SmallMatrix.hpp
@@ -1,8 +1,6 @@
 #ifndef SMALLMATRIX_hpp
 #define SMALLMATRIX_hpp
 
-#include "feddlib/core/FEDDCore.hpp"
-
 /*!
  Declaration of SmallMatrix
  
@@ -78,7 +76,7 @@ private:
 
 
 
-#include "SmallMatrix.hpp"
+
 
 template<class T>
 SmallMatrix<T>::SmallMatrix():

--- a/feddlib/core/General/tests/neumannBC.cpp
+++ b/feddlib/core/General/tests/neumannBC.cpp
@@ -1,7 +1,7 @@
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/problems/abstract/Problem.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include <Teuchos_GlobalMPISession.hpp>
 
 

--- a/feddlib/core/General/tests/write_read.cpp
+++ b/feddlib/core/General/tests/write_read.cpp
@@ -1,5 +1,5 @@
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/problems/abstract/Problem.hpp"
 #include <Teuchos_GlobalMPISession.hpp>

--- a/feddlib/core/IO/IO_Utils.hpp
+++ b/feddlib/core/IO/IO_Utils.hpp
@@ -17,22 +17,19 @@ namespace FEDD{
         Teuchos::RCP<Teuchos::ParameterList> parseParameterList(const std::string &fileName,
                                                                 const std::string &type         = "yaml")
         {
-            using std::logic_error;
-            using namespace Teuchos;
-
-            RCP<ParameterList> parameterList;
+            Teuchos::RCP<Teuchos::ParameterList> parameterList;
 
             if (!type.compare("yaml"))
             {
-                parameterList = getParametersFromYamlFile(fileName);
+                parameterList = Teuchos::getParametersFromYamlFile(fileName);
             }
             else if (!type.compare("xml"))
             {
-                parameterList = getParametersFromXmlFile(fileName);
+                parameterList = Teuchos::getParametersFromXmlFile(fileName);
             }
             else
             {
-                TEUCHOS_TEST_FOR_EXCEPTION(true,logic_error,"File type not supported.");
+                TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"File type not supported.");
             }
 
             return parameterList;
@@ -50,12 +47,8 @@ namespace FEDD{
                                                                      const std::string                      &nameName       = "ParameterLists File Names",
                                                                      const std::string                      &pathName       = "ParameterLists File Paths",
                                                                      const std::string                      &typeName       = "ParameterLists File Types")
-        {        
-            using std::string;
-            using std::logic_error;
-            using Teuchos::Array;
-            
-            Array<string> names(1,""), filePaths(1,""), fileTypes(1,"");
+        {                    
+            Teuchos::Array<std::string> names(1,""), filePaths(1,""), fileTypes(1,"");
             if (parameterList->isParameter(pathName))
             {
                 filePaths = parameterList->get(pathName,filePaths);
@@ -63,17 +56,17 @@ namespace FEDD{
                 if (parameterList->isParameter(nameName))
                 {
                     names = parameterList->get(nameName,names);
-                    TEUCHOS_TEST_FOR_EXCEPTION(names.size()!=filePaths.size(),logic_error,"names.size()!=filePaths.size()");
+                    TEUCHOS_TEST_FOR_EXCEPTION(names.size()!=filePaths.size(),std::logic_error,"names.size()!=filePaths.size()");
                 } else {
-                    TEUCHOS_TEST_FOR_EXCEPTION(true,logic_error,"ParameterLists File Names are not specified.");
+                    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"ParameterLists File Names are not specified.");
                 }
 
                 if (parameterList->isParameter(typeName))
                 {
                     fileTypes = parameterList->get(typeName,fileTypes);
-                    TEUCHOS_TEST_FOR_EXCEPTION(fileTypes.size()!=filePaths.size(),logic_error,"fileTypes.size()!=filePaths.size()");
+                    TEUCHOS_TEST_FOR_EXCEPTION(fileTypes.size()!=filePaths.size(),std::logic_error,"fileTypes.size()!=filePaths.size()");
                 } else {
-                    TEUCHOS_TEST_FOR_EXCEPTION(true,logic_error,"ParameterLists File Types are not specified.");
+                    TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,"ParameterLists File Types are not specified.");
                 }
 
                 int i = 0;

--- a/feddlib/core/LinearAlgebra/BlockMap.cpp
+++ b/feddlib/core/LinearAlgebra/BlockMap.cpp
@@ -1,6 +1,5 @@
-#include "BlockMap_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "BlockMap_decl.hpp"
 #include "BlockMap_def.hpp"
 namespace FEDD {
     template class BlockMap<default_lo, default_go, default_no>;

--- a/feddlib/core/LinearAlgebra/BlockMap.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMap.hpp
@@ -1,8 +1,8 @@
 #ifndef BlockMap_hpp
 #define BlockMap_hpp
 #include "BlockMap_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "BlockMap_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+     #include "BlockMap_def.hpp"
+#endif
 
 #endif // BlockMap_hpp

--- a/feddlib/core/LinearAlgebra/BlockMap_def.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMap_def.hpp
@@ -1,6 +1,6 @@
 #ifndef BlockMap_DEF_hpp
 #define BlockMap_DEF_hpp
-#include "BlockMap_decl.hpp"
+
 /*!
  Definition of BlockMap
  

--- a/feddlib/core/LinearAlgebra/BlockMatrix.cpp
+++ b/feddlib/core/LinearAlgebra/BlockMatrix.cpp
@@ -1,7 +1,5 @@
-
-#include "BlockMatrix_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "BlockMatrix_decl.hpp"
 #include "BlockMatrix_def.hpp"
 namespace FEDD {
     template class BlockMatrix<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/LinearAlgebra/BlockMatrix.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMatrix.hpp
@@ -1,9 +1,8 @@
 #ifndef BLOCKMATRIX_hpp
 #define BLOCKMATRIX_hpp
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "BlockMatrix_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "BlockMatrix_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "BlockMatrix_def.hpp"
+#endif
 
 #endif // BLOCKMATRIX_hpp

--- a/feddlib/core/LinearAlgebra/BlockMatrix_decl.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMatrix_decl.hpp
@@ -1,14 +1,16 @@
 #ifndef BLOCKMATRIX_DECL_hpp
 #define BLOCKMATRIX_DECL_hpp
 
+#include <Teuchos_Tuple.hpp>
+#include <Thyra_BlockedLinearOpBase.hpp>
+#include <Thyra_DefaultBlockedLinearOp_decl.hpp>
+
 #include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/General/SmallMatrix.hpp"
 #include "BlockMap.hpp"
 #include "BlockMultiVector.hpp"
 #include "Matrix.hpp"
-#include <Teuchos_Tuple.hpp>
-#include <Thyra_BlockedLinearOpBase.hpp>
-#include <Thyra_DefaultBlockedLinearOp_decl.hpp>
+
 /*!
  Declaration of BlockMatrix
 

--- a/feddlib/core/LinearAlgebra/BlockMatrix_def.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMatrix_def.hpp
@@ -1,6 +1,6 @@
 #ifndef BLOCKMATRIX_DEF_hpp
 #define BLOCKMATRIX_DEF_hpp
-#include "BlockMatrix_decl.hpp"
+
 /*!
  Definition of BlockMatrix
 

--- a/feddlib/core/LinearAlgebra/BlockMultiVector.cpp
+++ b/feddlib/core/LinearAlgebra/BlockMultiVector.cpp
@@ -1,6 +1,5 @@
-#include "BlockMultiVector_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "BlockMultiVector_decl.hpp"
 #include "BlockMultiVector_def.hpp"
 namespace FEDD {
     template class BlockMultiVector<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/LinearAlgebra/BlockMultiVector.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMultiVector.hpp
@@ -1,8 +1,8 @@
 #ifndef BlockMultiVector_hpp
 #define BlockMultiVector_hpp
 #include "BlockMultiVector_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "BlockMultiVector_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "BlockMultiVector_def.hpp"
+#endif
 
 #endif // BlockMultiVector_hpp

--- a/feddlib/core/LinearAlgebra/BlockMultiVector_decl.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMultiVector_decl.hpp
@@ -1,12 +1,12 @@
 #ifndef BlockMultiVector_DECL_hpp
 #define BlockMultiVector_DECL_hpp
 
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-#include "BlockMap.hpp"
-#include "MultiVector.hpp"
 #include <Thyra_ProductVectorSpaceBase.hpp>
 #include <Thyra_DefaultProductMultiVector_decl.hpp>
+#include <Teuchos_BLAS_types.hpp>
+
+#include "feddlib/core/FEDDCore.hpp"
+
 /*!
  Declaration of BlockMultiVector
  

--- a/feddlib/core/LinearAlgebra/BlockMultiVector_def.hpp
+++ b/feddlib/core/LinearAlgebra/BlockMultiVector_def.hpp
@@ -1,6 +1,8 @@
 #ifndef BlockMultiVector_DEF_hpp
 #define BlockMultiVector_DEF_hpp
-#include "BlockMultiVector_decl.hpp"
+
+#include "MultiVector.hpp"
+#include "BlockMap.hpp"
 
 /*!
  Defintion of BlockMultiVector

--- a/feddlib/core/LinearAlgebra/Map.cpp
+++ b/feddlib/core/LinearAlgebra/Map.cpp
@@ -1,6 +1,5 @@
-#include "Map_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Map_decl.hpp"
 #include "Map_def.hpp"
 namespace FEDD {
     template class Map<default_lo, default_go, default_no>;

--- a/feddlib/core/LinearAlgebra/Map.hpp
+++ b/feddlib/core/LinearAlgebra/Map.hpp
@@ -1,8 +1,8 @@
 #ifndef MAP_hpp
 #define MAP_hpp
 #include "Map_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "Map_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Map_def.hpp"
+#endif
 
 #endif // Map_hpp

--- a/feddlib/core/LinearAlgebra/Map_Xpetra.cpp
+++ b/feddlib/core/LinearAlgebra/Map_Xpetra.cpp
@@ -1,6 +1,5 @@
-#include "Map_Xpetra_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Map_Xpetra_decl.hpp"
 #include "Map_Xpetra_def.hpp"
 namespace FEDD {
     template class Map_Xpetra<default_lo, default_go, default_no>;

--- a/feddlib/core/LinearAlgebra/Map_Xpetra.hpp
+++ b/feddlib/core/LinearAlgebra/Map_Xpetra.hpp
@@ -1,8 +1,8 @@
 #ifndef MAP_Xpetra_hpp
 #define MAP_Xpetra_hpp
 #include "Map_Xpetra_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "Map_def.hpp"
-// #endif
+ #ifndef HAVE_EXPLICIT_INSTANTIATION
+     #include "Map_Xpetra_def.hpp"
+ #endif
 
 #endif // Map_hpp

--- a/feddlib/core/LinearAlgebra/Map_Xpetra_decl.hpp
+++ b/feddlib/core/LinearAlgebra/Map_Xpetra_decl.hpp
@@ -1,9 +1,6 @@
 #ifndef MAP_XPETRA_DECL_hpp
 #define MAP_XPETRA_DECL_hpp
 
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include <Xpetra_MapFactory.hpp>
 #include <Xpetra_MultiVectorFactory.hpp>
 #include <Xpetra_VectorFactory.hpp>
@@ -12,6 +9,9 @@
 #include <Teuchos_VerboseObject.hpp>
 #include <Xpetra_ThyraUtils.hpp>
 #include <Thyra_VectorSpaceBase_decl.hpp>
+
+#include "feddlib/core/FEDDCore.hpp"
+#include "feddlib/core/General/DefaultTypeDefs.hpp"
 
 /*!
  Declaration of Map

--- a/feddlib/core/LinearAlgebra/Map_Xpetra_def.hpp
+++ b/feddlib/core/LinearAlgebra/Map_Xpetra_def.hpp
@@ -1,6 +1,5 @@
 #ifndef MAP_XPETRA_DEF_hpp
 #define MAP_XPETRA_DEF_hpp
-#include "Map_Xpetra_decl.hpp"
 
 /*!
  Declaration of Map

--- a/feddlib/core/LinearAlgebra/Map_decl.hpp
+++ b/feddlib/core/LinearAlgebra/Map_decl.hpp
@@ -1,12 +1,7 @@
 #ifndef MAP_DECL_hpp
 #define MAP_DECL_hpp
 
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include <Teuchos_VerboseObject.hpp>
-#include <Thyra_VectorSpaceBase_decl.hpp>
-
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_Vector.hpp>
@@ -16,6 +11,11 @@
 #include <Thyra_TpetraVector.hpp>
 #include <Thyra_TpetraMultiVector.hpp>
 #include <Thyra_TpetraVectorSpace.hpp>
+#include <Thyra_VectorSpaceBase_decl.hpp>
+
+#include "feddlib/core/FEDDCore.hpp"
+
+
 /*!
  Declaration of Map
  

--- a/feddlib/core/LinearAlgebra/Map_def.hpp
+++ b/feddlib/core/LinearAlgebra/Map_def.hpp
@@ -1,6 +1,5 @@
 #ifndef MAP_DEF_hpp
 #define MAP_DEF_hpp
-#include "Map_decl.hpp"
 
 /*!
  Declaration of Map

--- a/feddlib/core/LinearAlgebra/Matrix.cpp
+++ b/feddlib/core/LinearAlgebra/Matrix.cpp
@@ -1,6 +1,5 @@
-#include "Matrix_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Matrix_decl.hpp"
 #include "Matrix_def.hpp"
 namespace FEDD {
     template class Matrix<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/LinearAlgebra/Matrix.hpp
+++ b/feddlib/core/LinearAlgebra/Matrix.hpp
@@ -1,8 +1,8 @@
 #ifndef MATRIX_hpp
 #define MATRIX_hpp
 #include "Matrix_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "Matrix_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Matrix_def.hpp"
+#endif
 
 #endif // MATRIX_hpp

--- a/feddlib/core/LinearAlgebra/Matrix_decl.hpp
+++ b/feddlib/core/LinearAlgebra/Matrix_decl.hpp
@@ -1,13 +1,6 @@
 #ifndef MATRIX_DECL_hpp
 #define MATRIX_DECL_hpp
 
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
-#include "Map.hpp"
-#include "MultiVector.hpp"
-#include "BlockMultiVector.hpp"
-
 #include <Teuchos_VerboseObject.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 #include <TpetraExt_MatrixMatrix.hpp>
@@ -16,6 +9,12 @@
 #include <Tpetra_CrsMatrix.hpp>
 //#include <Tpetra_MatrixMatrix.hpp>
 #include <MatrixMarket_Tpetra.hpp>
+
+#include "feddlib/core/FEDDCore.hpp"
+#include "Map.hpp"
+#include "MultiVector.hpp"
+#include "BlockMultiVector.hpp"
+
 
 /*!
  Declaration of Matrix

--- a/feddlib/core/LinearAlgebra/Matrix_def.hpp
+++ b/feddlib/core/LinearAlgebra/Matrix_def.hpp
@@ -1,6 +1,5 @@
 #ifndef MATRIX_DEF_hpp
 #define MATRIX_DEF_hpp
-#include "Matrix_decl.hpp"
 
 /*!
  Defintion of Matrix
@@ -12,7 +11,7 @@
  */
 
 namespace FEDD {
-//using namespace Teuchos;
+
 template <class SC, class LO, class GO, class NO>
 Matrix<SC,LO,GO,NO>::Matrix():
 	matrix_()

--- a/feddlib/core/LinearAlgebra/MultiVector.cpp
+++ b/feddlib/core/LinearAlgebra/MultiVector.cpp
@@ -1,7 +1,7 @@
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-#include "MultiVector_decl.hpp"
 
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "MultiVector_decl.hpp"
 #include "MultiVector_def.hpp"
 namespace FEDD {
     template class MultiVector<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/LinearAlgebra/MultiVector_decl.hpp
+++ b/feddlib/core/LinearAlgebra/MultiVector_decl.hpp
@@ -26,21 +26,21 @@
     #include <type_traits>
 #endif
 
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-#include "Map.hpp"
-#include <Thyra_LinearOpBase_decl.hpp>
-#include <Thyra_DefaultProductVectorSpace.hpp>
-#include <Thyra_TpetraThyraWrappers.hpp>
-#include <Teuchos_VerboseObject.hpp>
 #include <MatrixMarket_Tpetra.hpp>
-
+#include <Teuchos_VerboseObject.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_Export.hpp>
 #include <Tpetra_Import.hpp>
+#include <Thyra_DefaultProductVectorSpace.hpp>
+#include <Thyra_TpetraThyraWrappers.hpp>
+
+#include "feddlib/core/FEDDCore.hpp"
+#include "Map.hpp"
+#include "BlockMap.hpp"
+#include "BlockMultiVector.hpp"
 
 /*!
  Declaration of MultiVector

--- a/feddlib/core/Mesh/AABBTree.cpp
+++ b/feddlib/core/Mesh/AABBTree.cpp
@@ -1,8 +1,7 @@
-#include "AABBTree_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "AABBTree_decl.hpp"
 #include "AABBTree_def.hpp"
 namespace FEDD {
-    template class AABBTree<default_sc, default_lo, default_go, default_no>; // What to do here?
+    template class AABBTree<default_sc, default_lo, default_go, default_no>;
 }
 #endif  // HAVE_EXPLICIT_INSTANTIATION

--- a/feddlib/core/Mesh/AABBTree.hpp
+++ b/feddlib/core/Mesh/AABBTree.hpp
@@ -1,8 +1,7 @@
 #ifndef AABBTree_hpp
 #define AABBTree_hpp
 #include "AABBTree_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "AABBTree.hpp"
-// #endif
-
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "AABBTree_def.hpp"
+#endif
 #endif

--- a/feddlib/core/Mesh/AABBTree_decl.hpp
+++ b/feddlib/core/Mesh/AABBTree_decl.hpp
@@ -1,15 +1,16 @@
 #ifndef AABBTree_decl_hpp
 #define AABBTree_decl_hpp
 
+#include <list>
+#include <map>
+#include <tuple>
 
 #include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/core/FE/Elements.hpp"
 
-#include <list>
-#include <map>
-#include <tuple>
+
 /*!
 Declaration of AABBTree
 

--- a/feddlib/core/Mesh/AABBTree_def.hpp
+++ b/feddlib/core/Mesh/AABBTree_def.hpp
@@ -1,8 +1,6 @@
 #ifndef AABBTree_def_hpp
 #define AABBTree_def_hpp
 
-#include "AABBTree_decl.hpp"
-
 /*!
 Definition of AABBTree
 

--- a/feddlib/core/Mesh/Mesh.cpp
+++ b/feddlib/core/Mesh/Mesh.cpp
@@ -1,6 +1,5 @@
-#include "Mesh_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Mesh_decl.hpp"
 #include "Mesh_def.hpp"
 namespace FEDD {
     template class Mesh<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/Mesh/Mesh.hpp
+++ b/feddlib/core/Mesh/Mesh.hpp
@@ -1,8 +1,8 @@
 #ifndef Mesh_hpp
 #define Mesh_hpp
 #include "Mesh_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "Mesh_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Mesh_def.hpp"
+#endif
 
 #endif // Map_hpp

--- a/feddlib/core/Mesh/MeshInterface.cpp
+++ b/feddlib/core/Mesh/MeshInterface.cpp
@@ -1,6 +1,5 @@
-#include "MeshInterface_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "MeshInterface_decl.hpp"
 #include "MeshInterface_def.hpp"
 namespace FEDD {
     template class MeshInterface<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/Mesh/MeshInterface.hpp
+++ b/feddlib/core/Mesh/MeshInterface.hpp
@@ -1,8 +1,8 @@
 #ifndef MeshInterface_hpp
 #define MeshInterface_hpp
 #include "MeshInterface_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "MeshInterface_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "MeshInterface_def.hpp"
+#endif
 
 #endif // Map_hpp

--- a/feddlib/core/Mesh/MeshInterface_def.hpp
+++ b/feddlib/core/Mesh/MeshInterface_def.hpp
@@ -1,6 +1,5 @@
 #ifndef MESHINTERFACE_def_hpp
 #define MESHINTERFACE_def_hpp
-#include "MeshInterface_decl.hpp"
 
 /*!
  Definition of MeshInterface

--- a/feddlib/core/Mesh/MeshPartitioner.cpp
+++ b/feddlib/core/Mesh/MeshPartitioner.cpp
@@ -1,6 +1,5 @@
-#include "MeshPartitioner_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "MeshPartitioner_decl.hpp"
 #include "MeshPartitioner_def.hpp"
 namespace FEDD {
     template class MeshPartitioner<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/Mesh/MeshPartitioner.hpp
+++ b/feddlib/core/Mesh/MeshPartitioner.hpp
@@ -1,8 +1,8 @@
 #ifndef MeshPartitioner_hpp
 #define MeshPartitioner_hpp
 #include "MeshPartitioner_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "MeshPartitioner_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "MeshPartitioner_def.hpp"
+#endif
 
 #endif // Map_hpp

--- a/feddlib/core/Mesh/MeshPartitioner_decl.hpp
+++ b/feddlib/core/Mesh/MeshPartitioner_decl.hpp
@@ -1,10 +1,6 @@
 #ifndef MeshPartitioner_decl_hpp
 #define MeshPartitioner_decl_hpp
 
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-#include "feddlib/core/FE/Domain.hpp"
-
 #define FEDD_HAVE_METIS
 #define FEDD_HAVE_PARMETIS
 
@@ -14,6 +10,10 @@
 #ifdef FEDD_HAVE_PARMETIS
 #include <parmetis.h>
 #endif
+
+#include "feddlib/core/FEDDCore.hpp"
+#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include "feddlib/core/FE/Domain.hpp"
 
 /*!
  Definition of MeshPartitioner

--- a/feddlib/core/Mesh/MeshPartitioner_def.hpp
+++ b/feddlib/core/Mesh/MeshPartitioner_def.hpp
@@ -1,8 +1,6 @@
 #ifndef MeshPartitioner_def_hpp
 #define MeshPartitioner_def_hpp
 
-#include "MeshPartitioner_decl.hpp"
-
 /*!
  Definition of MeshPartitioner
  

--- a/feddlib/core/Mesh/MeshStructured.cpp
+++ b/feddlib/core/Mesh/MeshStructured.cpp
@@ -1,6 +1,5 @@
-#include "MeshStructured_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "MeshStructured_decl.hpp"
 #include "MeshStructured_def.hpp"
 namespace FEDD {
     template class MeshStructured<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/Mesh/MeshStructured.hpp
+++ b/feddlib/core/Mesh/MeshStructured.hpp
@@ -1,8 +1,8 @@
 #ifndef MeshStructured_hpp
 #define MeshStructured_hpp
 #include "MeshStructured_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "MeshStructured_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "MeshStructured_def.hpp"
+#endif
 
-#endif // MeshUnstruturedNEW_hpp
+#endif

--- a/feddlib/core/Mesh/MeshStructured_decl.hpp
+++ b/feddlib/core/Mesh/MeshStructured_decl.hpp
@@ -1,5 +1,6 @@
 #ifndef MeshStructured_decl_hpp
 #define MeshStructured_decl_hpp
+
 #include "feddlib/core/Utils/FEDDUtils.hpp"
 #include "Mesh.hpp"
 

--- a/feddlib/core/Mesh/MeshStructured_def.hpp
+++ b/feddlib/core/Mesh/MeshStructured_def.hpp
@@ -1,6 +1,5 @@
 #ifndef MeshStructured_def_hpp
 #define MeshStructured_def_hpp
-#include "MeshStructured_decl.hpp"
 
 /*!
  Definition of MeshStructured

--- a/feddlib/core/Mesh/MeshUnstructured.cpp
+++ b/feddlib/core/Mesh/MeshUnstructured.cpp
@@ -1,6 +1,5 @@
-#include "MeshUnstructured_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "MeshUnstructured_decl.hpp"
 #include "MeshUnstructured_def.hpp"
 namespace FEDD {
     template class MeshUnstructured<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/core/Mesh/MeshUnstructured.hpp
+++ b/feddlib/core/Mesh/MeshUnstructured.hpp
@@ -1,8 +1,8 @@
 #ifndef MeshUnstructured_hpp
 #define MeshUnstructured_hpp
 #include "MeshUnstructured_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "MeshUnstructured_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "MeshUnstructured_def.hpp"
+#endif
 
 #endif

--- a/feddlib/core/Mesh/MeshUnstructured_decl.hpp
+++ b/feddlib/core/Mesh/MeshUnstructured_decl.hpp
@@ -9,6 +9,8 @@
 #include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
 #include "feddlib/core/FE/TriangleElements.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
+#include "feddlib/core/LinearAlgebra/MultiVector.hpp"
+
 /*!
  Declaration of MeshUnstructured
  

--- a/feddlib/core/Mesh/MeshUnstructured_def.hpp
+++ b/feddlib/core/Mesh/MeshUnstructured_def.hpp
@@ -1,7 +1,5 @@
 #ifndef MESHUNSTRUCTURED_def_hpp
 #define MESHUNSTRUCTURED_def_hpp
-#include "MeshUnstructured_decl.hpp"
-#include "feddlib/core/LinearAlgebra/MultiVector_def.hpp"
 
 /*!
  Definition of MeshUnstructured

--- a/feddlib/core/Mesh/Mesh_def.hpp
+++ b/feddlib/core/Mesh/Mesh_def.hpp
@@ -1,8 +1,6 @@
 #ifndef Mesh_def_hpp
 #define Mesh_def_hpp
 
-#include "Mesh_decl.hpp"
-
 /*!
 Definition of Mesh
 

--- a/feddlib/problems/Solver/CMakeLists.txt
+++ b/feddlib/problems/Solver/CMakeLists.txt
@@ -2,9 +2,9 @@ set(Solver_HEADERS
     Solver/DAESolverInTime_decl.hpp
     Solver/DAESolverInTime_def.hpp
     Solver/DAESolverInTime.hpp
+	Solver/LinearSolver.hpp
 	Solver/LinearSolver_decl.hpp
 	Solver/LinearSolver_def.hpp
-	Solver/LinearSolver.hpp
     Solver/NonLinearSolver.hpp
     Solver/NonLinearSolver_decl.hpp
     Solver/NonLinearSolver_def.hpp

--- a/feddlib/problems/Solver/DAESolverInTime.cpp
+++ b/feddlib/problems/Solver/DAESolverInTime.cpp
@@ -1,5 +1,5 @@
-#include "DAESolverInTime_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "DAESolverInTime_decl.hpp"
 #include "DAESolverInTime_def.hpp"
 namespace FEDD{
     template class DAESolverInTime<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/Solver/DAESolverInTime.hpp
+++ b/feddlib/problems/Solver/DAESolverInTime.hpp
@@ -3,8 +3,8 @@
 
 #include "DAESolverInTime_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "DAESolverInTime_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "DAESolverInTime_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/Solver/DAESolverInTime_decl.hpp
+++ b/feddlib/problems/Solver/DAESolverInTime_decl.hpp
@@ -1,13 +1,10 @@
 #ifndef DAESOLVERINTIME_DECL_hpp
 #define DAESOLVERINTIME_DECL_hpp
 
-#include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/problems/problems_config.h"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/General/ExporterTxt.hpp"
-
-
 
 #include "NonLinearSolver.hpp"
 #include "TimeSteppingTools.hpp"
@@ -22,6 +19,13 @@
  */
 
 namespace FEDD {
+
+template <class SC, class LO, class GO, class NO>
+class FSI;
+template <class SC, class LO, class GO, class NO>
+class MeshUnstructured;
+template <class SC, class LO, class GO, class NO>
+class Domain;
 
 template <class SC = default_sc, class LO = default_lo, class GO = default_go, class NO = default_no>
 class DAESolverInTime {

--- a/feddlib/problems/Solver/DAESolverInTime_def.hpp
+++ b/feddlib/problems/Solver/DAESolverInTime_def.hpp
@@ -1,7 +1,11 @@
 #ifndef DAESOLVERINTIME_DEF_hpp
 #define DAESOLVERINTIME_DEF_hpp
-#include "DAESolverInTime_decl.hpp"
 
+
+#include "feddlib/problems/specific/FSI.hpp"
+#include "feddlib/core/Mesh/MeshUnstructured.hpp"
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/FE/FE.hpp"
 
 /*!
  Definition of DAESolverInTime

--- a/feddlib/problems/Solver/LinearSolver.cpp
+++ b/feddlib/problems/Solver/LinearSolver.cpp
@@ -1,5 +1,5 @@
-#include "LinearSolver_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "LinearSolver_decl.hpp"
 #include "LinearSolver_def.hpp"
 namespace FEDD{
 template class LinearSolver<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/Solver/LinearSolver.hpp
+++ b/feddlib/problems/Solver/LinearSolver.hpp
@@ -3,8 +3,8 @@
 
 #include "LinearSolver_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "LinearSolver_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "LinearSolver_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/Solver/LinearSolver_decl.hpp
+++ b/feddlib/problems/Solver/LinearSolver_decl.hpp
@@ -3,10 +3,12 @@
 
 #include "feddlib/problems/problems_config.h"
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/problems/abstract/TimeProblem.hpp"
+#include "feddlib/core/LinearAlgebra/BlockMultiVector.hpp"
 
 #include <Thyra_PreconditionerBase.hpp>
 #include <Thyra_DefaultZeroLinearOp_decl.hpp>
+#include <Thyra_BlockedLinearOpBase.hpp>
+
 /*!
  Declaration of LinearSolver
  

--- a/feddlib/problems/Solver/LinearSolver_def.hpp
+++ b/feddlib/problems/Solver/LinearSolver_def.hpp
@@ -1,6 +1,10 @@
 #ifndef LinearSolver_DEF_hpp
 #define LinearSolver_DEF_hpp
-#include "LinearSolver_decl.hpp"
+
+#include "feddlib/problems/abstract/TimeProblem.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
+#include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
+
 /*!
  Definition of LinearSolver
 

--- a/feddlib/problems/Solver/NonLinearSolver.cpp
+++ b/feddlib/problems/Solver/NonLinearSolver.cpp
@@ -1,5 +1,5 @@
-#include "NonLinearSolver_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "NonLinearSolver_decl.hpp"
 #include "NonLinearSolver_def.hpp"
 namespace FEDD{
     template class NonLinearSolver<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/Solver/NonLinearSolver.hpp
+++ b/feddlib/problems/Solver/NonLinearSolver.hpp
@@ -3,8 +3,8 @@
 
 #include "NonLinearSolver_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "NonLinearSolver_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "NonLinearSolver_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/Solver/NonLinearSolver_decl.hpp
+++ b/feddlib/problems/Solver/NonLinearSolver_decl.hpp
@@ -3,7 +3,7 @@
 #include "feddlib/problems/problems_config.h"
 #include "feddlib/problems/abstract/NonLinearProblem.hpp"
 #include "feddlib/problems/abstract/TimeProblem.hpp"
-
+#include "feddlib/core/General/ExporterTxt.hpp"
 
 #include <boost/function.hpp>
 

--- a/feddlib/problems/Solver/NonLinearSolver_def.hpp
+++ b/feddlib/problems/Solver/NonLinearSolver_def.hpp
@@ -1,6 +1,6 @@
 #ifndef NONLINEARSOLVER_DEF_hpp
 #define NONLINEARSOLVER_DEF_hpp
-#include "NonLinearSolver_decl.hpp"
+
 /*!
  Definition of NonLinearSolver
 

--- a/feddlib/problems/Solver/PrecBlock2x2.cpp
+++ b/feddlib/problems/Solver/PrecBlock2x2.cpp
@@ -1,6 +1,5 @@
-#include "PrecBlock2x2_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "PrecBlock2x2_decl.hpp"
 #include "PrecBlock2x2_def.hpp"
 namespace FEDD {
 template class PrecBlock2x2<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/Solver/PrecBlock2x2.hpp
+++ b/feddlib/problems/Solver/PrecBlock2x2.hpp
@@ -2,8 +2,8 @@
 #define PrecBlock2x2_hpp
 
 #include "PrecBlock2x2_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "Preconditioner_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "PrecBlock2x2_def.hpp"
+#endif
 
-#endif // PRECONDMANAGERFORSCH_hpp
+#endif

--- a/feddlib/problems/Solver/PrecOpFaCSI.cpp
+++ b/feddlib/problems/Solver/PrecOpFaCSI.cpp
@@ -1,6 +1,5 @@
-#include "PrecOpFaCSI_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "PrecOpFaCSI_decl.hpp"
 #include "PrecOpFaCSI_def.hpp"
 namespace FEDD {
 template class PrecOpFaCSI<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/Solver/PrecOpFaCSI.hpp
+++ b/feddlib/problems/Solver/PrecOpFaCSI.hpp
@@ -2,8 +2,8 @@
 #define PrecOpFaCSI_hpp
 
 #include "PrecOpFaCSI_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "Preconditioner_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "PrecOpFaCSI_def.hpp"
+#endif
 
-#endif // PRECONDMANAGERFORSCH_hpp
+#endif

--- a/feddlib/problems/Solver/PrecOpFaCSI_def.hpp
+++ b/feddlib/problems/Solver/PrecOpFaCSI_def.hpp
@@ -1,8 +1,10 @@
 #ifndef PrecOpFaCSI_DEF_hpp
 #define PrecOpFaCSI_DEF_hpp
-#include "PrecOpFaCSI_decl.hpp"
+
 #include <Thyra_TpetraMultiVector_decl.hpp>
 #include <Teuchos_VerboseObject.hpp>
+#include <Teuchos_Range1D.hpp>
+
 /*!
  Definition of PrecOpFaCSI
 
@@ -13,7 +15,6 @@
  */
 
 namespace FEDD {
-using namespace Thyra;
         
 // Constructors
 
@@ -189,9 +190,9 @@ void PrecOpFaCSI<SC,LO,GO,NO>::initialize(){
 
 template<class SC, class LO, class GO, class NO>
 void PrecOpFaCSI<SC,LO,GO,NO>::applyIt(
-                                         const EOpTransp M_trans,
-                                         const MultiVectorBase<SC> &X_in,
-                                         const Ptr<MultiVectorBase<SC> > &Y_inout,
+                                         const Thyra::EOpTransp M_trans,
+                                         const Thyra::MultiVectorBase<SC> &X_in,
+                                         const Thyra::Ptr<Thyra::MultiVectorBase<SC> > &Y_inout,
                                          const SC alpha,
                                          const SC beta
                                          ) const
@@ -202,44 +203,43 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyIt(
     
 template<class SC, class LO, class GO, class NO>
 void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
-                                   const EOpTransp M_trans,
-                                   const MultiVectorBase<SC> &X_in,
-                                   const Ptr<MultiVectorBase<SC> > &Y_inout,
+                                   const Thyra::EOpTransp M_trans,
+                                   const Thyra::MultiVectorBase<SC> &X_in,
+                                   const Thyra::Ptr<Thyra::MultiVectorBase<SC> > &Y_inout,
                                    const SC alpha,
                                    const SC beta
                                    ) const
 {
     Teuchos::RCP<Teuchos::FancyOStream> out = Teuchos::VerboseObjectBase::getDefaultOStream();
     
-    using Teuchos::rcpFromRef;
     typedef Teuchos::ScalarTraits<SC> ST;
-    typedef RCP<MultiVectorBase<SC> > MultiVectorPtr;
-    typedef RCP<const MultiVectorBase<SC> > ConstMultiVectorPtr;
-    typedef RCP<const LinearOpBase<SC> > ConstLinearOpPtr;
+    typedef Teuchos::RCP<Thyra::MultiVectorBase<SC> > MultiVectorPtr;
+    typedef Teuchos::RCP<const Thyra::MultiVectorBase<SC> > ConstMultiVectorPtr;
+    typedef Teuchos::RCP<const Thyra::LinearOpBase<SC> > ConstLinearOpPtr;
 
     int rank = comm_->getRank();
     if (onlyDiagonal_) {
         
         Teuchos::RCP<const Thyra::ProductMultiVectorBase<SC> > X
-        = Teuchos::rcp_dynamic_cast<const Thyra::ProductMultiVectorBase<SC> > ( rcpFromRef(X_in) );
+        = Teuchos::rcp_dynamic_cast<const Thyra::ProductMultiVectorBase<SC> > ( Teuchos::rcpFromRef(X_in) );
         
         Teuchos::RCP< Thyra::ProductMultiVectorBase<SC> > Y
         = Teuchos::rcp_dynamic_cast< Thyra::ProductMultiVectorBase<SC> > ( rcpFromPtr(Y_inout) );
         
         Y_inout->assign(0.);
 
-        Teuchos::RCP< const MultiVectorBase< SC > > X_s = X->getMultiVectorBlock(2);
-        Teuchos::RCP< MultiVectorBase< SC > > Y_s = Y->getNonconstMultiVectorBlock(2);
+        Teuchos::RCP< const Thyra::MultiVectorBase< SC > > X_s = X->getMultiVectorBlock(2);
+        Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_s = Y->getNonconstMultiVectorBlock(2);
 
         
-        Teuchos::RCP< const MultiVectorBase< SC > > X_fv = X->getMultiVectorBlock(0);
-        Teuchos::RCP< MultiVectorBase< SC > > Y_fv = Y->getNonconstMultiVectorBlock(0);
-        Teuchos::RCP< const MultiVectorBase< SC > > X_fp = X->getMultiVectorBlock(1);
-        Teuchos::RCP< MultiVectorBase< SC > > Y_fp = Y->getNonconstMultiVectorBlock(1);
+        Teuchos::RCP< const Thyra::MultiVectorBase< SC > > X_fv = X->getMultiVectorBlock(0);
+        Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_fv = Y->getNonconstMultiVectorBlock(0);
+        Teuchos::RCP< const Thyra::MultiVectorBase< SC > > X_fp = X->getMultiVectorBlock(1);
+        Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_fp = Y->getNonconstMultiVectorBlock(1);
         
         
-        Teuchos::RCP< MultiVectorBase< SC > > Y_l = Y->getNonconstMultiVectorBlock(3);
-        Teuchos::RCP<const MultiVectorBase< SC > > X_l = X->getMultiVectorBlock(3);
+        Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_l = Y->getNonconstMultiVectorBlock(3);
+        Teuchos::RCP<const Thyra::MultiVectorBase< SC > > X_l = X->getMultiVectorBlock(3);
 
         assign(Y_fv.ptr(), *X_fv);
         assign(Y_fp.ptr(), *X_fp);
@@ -278,7 +278,7 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
 //
 //        
 //        if (useSolidPreconditioner_)
-//            sInv_->apply(NOTRANS, *X_s, Y_s.ptr(), 1., 0.);
+//            sInv_->apply(Thyra::NOTRANS, *X_s, Y_s.ptr(), 1., 0.);
 //        else
 //            assign(Y_s.ptr(), *X_s);
 //        
@@ -323,17 +323,17 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
 //                }
 //                //We can/should speedup this process
 //                copyToMono(X_fluid);
-//                fInv_->apply(NOTRANS, *X_fmono_, Y_fmono_.ptr(), 1., 0.);
+//                fInv_->apply(Thyra::NOTRANS, *X_fmono_, Y_fmono_.ptr(), 1., 0.);
 //                copyFromMono(Y_fluid);
 //            }
 //            else{
 //                Teuchos::RCP< Thyra::ProductMultiVectorBase<SC> > prodX_f = Thyra::defaultProductMultiVector<SC>( productRangeFluid_, X_fluid );
 //                Teuchos::RCP< Thyra::ProductMultiVectorBase<SC> > prodY_f = Thyra::defaultProductMultiVector<SC>( productRangeFluid_, Y_fluid );
 //                
-//                Teuchos::RCP< MultiVectorBase<SC> > X_f = Teuchos::rcp_dynamic_cast<MultiVectorBase< SC > >(prodX_f);
-//                Teuchos::RCP< MultiVectorBase<SC> > Y_f = Teuchos::rcp_dynamic_cast<MultiVectorBase< SC > >(prodY_f);
+//                Teuchos::RCP< Thyra::MultiVectorBase<SC> > X_f = Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase< SC > >(prodX_f);
+//                Teuchos::RCP< Thyra::MultiVectorBase<SC> > Y_f = Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase< SC > >(prodY_f);
 //                
-//                fInv_->apply(NOTRANS, *X_f, Y_f.ptr(), 1., 0.);
+//                fInv_->apply(Thyra::NOTRANS, *X_f, Y_f.ptr(), 1., 0.);
 //            }
 //        }
 //        else{
@@ -366,14 +366,14 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
     }
     else{
     Teuchos::RCP<const Thyra::ProductMultiVectorBase<SC> > X
-        = Teuchos::rcp_dynamic_cast<const Thyra::ProductMultiVectorBase<SC> > ( rcpFromRef(X_in) );
+        = Teuchos::rcp_dynamic_cast<const Thyra::ProductMultiVectorBase<SC> > ( Teuchos::rcpFromRef(X_in) );
 
     Teuchos::RCP< Thyra::ProductMultiVectorBase<SC> > Y
         = Teuchos::rcp_dynamic_cast< Thyra::ProductMultiVectorBase<SC> > ( rcpFromPtr(Y_inout) );
 
     
 //    Teuchos::RCP<const Thyra::ProductMultiVectorBase<SC> >
-//    X = Thyra::castOrCreateSingleBlockProductMultiVector<SC>( this->defaultProductDomain_, rcpFromRef(X_in) );
+//    X = Thyra::castOrCreateSingleBlockProductMultiVector<SC>( this->defaultProductDomain_, Teuchos::rcpFromRef(X_in) );
 //    Teuchos::RCP<Thyra::ProductMultiVectorBase<SC> >
 //    Y = Thyra::nonconstCastOrCreateSingleBlockProductMultiVector<SC>( this->defaultProductRange_, rcpFromPtr(Y_inout) );
     Y_inout->assign(0.);
@@ -387,8 +387,8 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
 //    std::cout << "Y_inoutin" << std::endl;
 //    Y_inout->describe(*out,Teuchos::VERB_EXTREME);
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
-    Teuchos::RCP< const MultiVectorBase< SC > > X_s = X->getMultiVectorBlock(2);
-    Teuchos::RCP< MultiVectorBase< SC > > Y_s = Y->getNonconstMultiVectorBlock(2);
+    Teuchos::RCP< const Thyra::MultiVectorBase< SC > > X_s = X->getMultiVectorBlock(2);
+    Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_s = Y->getNonconstMultiVectorBlock(2);
         
         
     Teuchos::RCP< const Thyra::TpetraMultiVector< SC, LO, GO, NO > > XsTpetra =
@@ -413,15 +413,15 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
     
     // apply solid preconditioner
     if (useSolidPreconditioner_)
-        sInv_->apply(NOTRANS, *X_s, Y_s.ptr(), 1., 0.);
+        sInv_->apply(Thyra::NOTRANS, *X_s, Y_s.ptr(), 1., 0.);
     else
         assign(Y_s.ptr(), *X_s);
     
 //    std::cout << "Ys" << std::endl;
 //    Y_s->describe(*out,Teuchos::VERB_EXTREME);
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
-    Teuchos::RCP< const MultiVectorBase< SC > > X_g;
-    Teuchos::RCP< MultiVectorBase< SC > > Y_g;
+    Teuchos::RCP< const Thyra::MultiVectorBase< SC > > X_g;
+    Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_g;
     // apply geometry preconditioner
     if ( !gInv_.is_null() ) {
         X_g = X->getMultiVectorBlock(4);
@@ -429,21 +429,21 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
 
         assign(Y_g.ptr(), *X_g);
 
-        C4_->apply(NOTRANS, *Y_s, Y_g.ptr(), -1., 1.);
+        C4_->apply(Thyra::NOTRANS, *Y_s, Y_g.ptr(), -1., 1.);
         
-        gInv_->apply(NOTRANS, *Y_g, Y_g.ptr(), 1., 0.);
+        gInv_->apply(Thyra::NOTRANS, *Y_g, Y_g.ptr(), 1., 0.);
     }
     
-    Teuchos::RCP< const MultiVectorBase< SC > > X_l = X->getMultiVectorBlock(3);
-    Teuchos::RCP< MultiVectorBase< SC > > Y_l = Y->getNonconstMultiVectorBlock(3);
+    Teuchos::RCP< const Thyra::MultiVectorBase< SC > > X_l = X->getMultiVectorBlock(3);
+    Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_l = Y->getNonconstMultiVectorBlock(3);
 
     assign(Y_l.ptr(), *X_l);
 //    std::cout << "Yl pre c2 apply" << std::endl;
 //    Y_l->describe(*out,Teuchos::VERB_EXTREME);
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
     
-    C2_->apply( NOTRANS, *Y_s, Y_l.ptr(), -1., 1. );
-//    C2_->apply( NOTRANS, *Y_s, Y_l.ptr(), 1., 0. );
+    C2_->apply( Thyra::NOTRANS, *Y_s, Y_l.ptr(), -1., 1. );
+//    C2_->apply( Thyra::NOTRANS, *Y_s, Y_l.ptr(), 1., 0. );
 //    std::cout << "Yl after c2 apply" << std::endl;
 //    Y_l->describe(*out,Teuchos::VERB_EXTREME);
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
@@ -453,8 +453,8 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
 //    Y_l->describe(*out,Teuchos::VERB_EXTREME);
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
     
-    Teuchos::RCP< const MultiVectorBase< SC > > X_fv = X->getMultiVectorBlock(0);
-    Teuchos::RCP< MultiVectorBase< SC > > Y_fv = Y->getNonconstMultiVectorBlock(0);
+    Teuchos::RCP< const Thyra::MultiVectorBase< SC > > X_fv = X->getMultiVectorBlock(0);
+    Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_fv = Y->getNonconstMultiVectorBlock(0);
     assign(Y_fv.ptr(), *X_fv);
     //    if (Z_fv_.is_null())
 //        Z_fv_ = X_fv->clone_mv();
@@ -463,8 +463,8 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
     
 
     
-    Teuchos::RCP< const MultiVectorBase< SC > > X_fp = X->getMultiVectorBlock(1);
-    Teuchos::RCP< MultiVectorBase< SC > > Y_fp = Y->getNonconstMultiVectorBlock(1);
+    Teuchos::RCP< const Thyra::MultiVectorBase< SC > > X_fp = X->getMultiVectorBlock(1);
+    Teuchos::RCP< Thyra::MultiVectorBase< SC > > Y_fp = Y->getNonconstMultiVectorBlock(1);
     assign(Y_fp.ptr(), *X_fp);
 //    if (Z_fp_.is_null())
 //        Z_fp_ = X_fv->clone_mv();
@@ -478,8 +478,8 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
 //    Y_fp->describe(*out,Teuchos::VERB_EXTREME);
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
     if (!shape_v_.is_null() && !shape_p_.is_null()) {
-        shape_v_->apply(NOTRANS, *Y_g, Y_fv.ptr(), -1., 1.);
-        shape_p_->apply(NOTRANS, *Y_g, Y_fp.ptr(), -1., 1.);
+        shape_v_->apply(Thyra::NOTRANS, *Y_g, Y_fv.ptr(), -1., 1.);
+        shape_p_->apply(Thyra::NOTRANS, *Y_g, Y_fp.ptr(), -1., 1.);
     }
     
     
@@ -501,10 +501,10 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
     if (tmp_l_.is_null())
         tmp_l_ = Y_l->clone_mv();
 
-    C1_->apply(NOTRANS, *Y_fv, tmp_l_.ptr(), 1., 0);
-    C1T_->apply(NOTRANS, *tmp_l_, Y_fv.ptr(), -1., 1.);
+    C1_->apply(Thyra::NOTRANS, *Y_fv, tmp_l_.ptr(), 1., 0);
+    C1T_->apply(Thyra::NOTRANS, *tmp_l_, Y_fv.ptr(), -1., 1.);
     
-    C1T_->apply(NOTRANS, *Y_l, Y_fv.ptr(), 1., 1.);
+    C1T_->apply(Thyra::NOTRANS, *Y_l, Y_fv.ptr(), 1., 1.);
     
 //    std::cout << "W_fv" << std::endl;
 //    Y_fv->describe(*out,Teuchos::VERB_EXTREME);
@@ -544,17 +544,17 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
             }
             //We can/should speedup this process
             copyToMono(X_fluid);
-            fInv_->apply(NOTRANS, *X_fmono_, Y_fmono_.ptr(), 1., 0.);
+            fInv_->apply(Thyra::NOTRANS, *X_fmono_, Y_fmono_.ptr(), 1., 0.);
             copyFromMono(Y_fluid);
         }
         else{
             Teuchos::RCP< Thyra::ProductMultiVectorBase<SC> > prodX_f = Thyra::defaultProductMultiVector<SC>( productRangeFluid_, X_fluid );
             Teuchos::RCP< Thyra::ProductMultiVectorBase<SC> > prodY_f = Thyra::defaultProductMultiVector<SC>( productRangeFluid_, Y_fluid );
             
-            Teuchos::RCP< MultiVectorBase<SC> > X_f = Teuchos::rcp_dynamic_cast<MultiVectorBase< SC > >(prodX_f);
-            Teuchos::RCP< MultiVectorBase<SC> > Y_f = Teuchos::rcp_dynamic_cast<MultiVectorBase< SC > >(prodY_f);
+            Teuchos::RCP< Thyra::MultiVectorBase<SC> > X_f = Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase< SC > >(prodX_f);
+            Teuchos::RCP< Thyra::MultiVectorBase<SC> > Y_f = Teuchos::rcp_dynamic_cast<Thyra::MultiVectorBase< SC > >(prodY_f);
             
-            fInv_->apply(NOTRANS, *X_f, Y_f.ptr(), 1., 0.);
+            fInv_->apply(Thyra::NOTRANS, *X_f, Y_f.ptr(), 1., 0.);
         }
     }
     else{
@@ -570,13 +570,13 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
 
 
-    fBT_->apply(NOTRANS, *Y_fp, Z_fv_.ptr(), -1., 1.);
+    fBT_->apply(Thyra::NOTRANS, *Y_fp, Z_fv_.ptr(), -1., 1.);
 
 //    std::cout << "W_fv after BT" << std::endl;
 //    W_fv->describe(*out,Teuchos::VERB_EXTREME);
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
     
-    fF_->apply(NOTRANS, *Y_fv, Z_fv_.ptr(), -1., 1.);
+    fF_->apply(Thyra::NOTRANS, *Y_fv, Z_fv_.ptr(), -1., 1.);
 
 //    std::cout << "W_fv after F" << std::endl;
 //    W_fv->describe(*out,Teuchos::VERB_EXTREME);
@@ -586,7 +586,7 @@ void PrecOpFaCSI<SC,LO,GO,NO>::applyImpl(
 //    Z_fv_->describe(*out,Teuchos::VERB_EXTREME);
 //    comm_->barrier();    comm_->barrier();    comm_->barrier();
     
-    C1_->apply(NOTRANS, *Z_fv_, Y_l.ptr(), 1., 0.);
+    C1_->apply(Thyra::NOTRANS, *Z_fv_, Y_l.ptr(), 1., 0.);
     
 //    std::cout << "Y_l after C1" << std::endl;
 //    Y_l->describe(*out,Teuchos::VERB_EXTREME);
@@ -645,10 +645,10 @@ void PrecOpFaCSI<SC,LO,GO,NO>::copyToMono( Teuchos::Array< Teuchos::RCP< Thyra::
     const LO localSubDim_p = mpiVS_p->localSubDim();
     
     Teuchos::RCP<Thyra::DetachedMultiVectorView<SC> > thyData_v =
-    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( X_fluid[0] ,Range1D(localOffset_v,localOffset_v+localSubDim_v-1) ) );
+    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( X_fluid[0] ,Teuchos::Range1D(localOffset_v,localOffset_v+localSubDim_v-1) ) );
     
     Teuchos::RCP<Thyra::DetachedMultiVectorView<SC> > thyData_p =
-    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( X_fluid[1] ,Range1D(localOffset_p,localOffset_p+localSubDim_p-1) ) );
+    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( X_fluid[1] ,Teuchos::Range1D(localOffset_p,localOffset_p+localSubDim_p-1) ) );
     
     Teuchos::RCP<const Thyra::SpmdVectorSpaceBase<SC> > mpiVS_mono = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceBase<SC> >(X_fmono_->range());
     
@@ -656,7 +656,7 @@ void PrecOpFaCSI<SC,LO,GO,NO>::copyToMono( Teuchos::Array< Teuchos::RCP< Thyra::
     const LO localSubDim_mono = mpiVS_mono->localSubDim();
     
     Teuchos::RCP<Thyra::DetachedMultiVectorView<SC> > thyData_fluid =
-    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( X_fmono_ ,Range1D(localOffset_mono,localOffset_mono+localSubDim_mono-1) ) );
+    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( X_fmono_ ,Teuchos::Range1D(localOffset_mono,localOffset_mono+localSubDim_mono-1) ) );
 
     for (int j=0; j<X_fluid[0]->domain()->dim(); j++) {
         
@@ -683,10 +683,10 @@ void PrecOpFaCSI<SC,LO,GO,NO>::copyFromMono(Teuchos::Array< Teuchos::RCP< Thyra:
     const LO localSubDim_p = mpiVS_p->localSubDim();
     
     Teuchos::RCP<Thyra::DetachedMultiVectorView<SC> > thyData_v =
-    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( Y_fluid[0] ,Range1D(localOffset_v,localOffset_v+localSubDim_v-1) ) );
+    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( Y_fluid[0] ,Teuchos::Range1D(localOffset_v,localOffset_v+localSubDim_v-1) ) );
     
     Teuchos::RCP<Thyra::DetachedMultiVectorView<SC> > thyData_p =
-    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( Y_fluid[1] ,Range1D(localOffset_p,localOffset_p+localSubDim_p-1) ) );
+    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( Y_fluid[1] ,Teuchos::Range1D(localOffset_p,localOffset_p+localSubDim_p-1) ) );
     
     Teuchos::RCP<const Thyra::SpmdVectorSpaceBase<SC> > mpiVS_mono = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceBase<SC> >(Y_fmono_->range());
     
@@ -694,7 +694,7 @@ void PrecOpFaCSI<SC,LO,GO,NO>::copyFromMono(Teuchos::Array< Teuchos::RCP< Thyra:
     const LO localSubDim_mono = mpiVS_mono->localSubDim();
     
     Teuchos::RCP<Thyra::DetachedMultiVectorView<SC> > thyData_fluid =
-    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( Y_fmono_ ,Range1D(localOffset_mono,localOffset_mono+localSubDim_mono-1) ) );
+    Teuchos::rcp(new Thyra::DetachedMultiVectorView<SC>( Y_fmono_ ,Teuchos::Range1D(localOffset_mono,localOffset_mono+localSubDim_mono-1) ) );
     
     for (int j=0; j<Y_fluid[0]->domain()->dim(); j++) {
         

--- a/feddlib/problems/Solver/Preconditioner.cpp
+++ b/feddlib/problems/Solver/Preconditioner.cpp
@@ -1,6 +1,5 @@
-#include "Preconditioner_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Preconditioner_decl.hpp"
 #include "Preconditioner_def.hpp"
 namespace FEDD {
 template class Preconditioner<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/Solver/Preconditioner.hpp
+++ b/feddlib/problems/Solver/Preconditioner.hpp
@@ -2,8 +2,8 @@
 #define Preconditioner_hpp
 
 #include "Preconditioner_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "Preconditioner_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Preconditioner_def.hpp"
+#endif
 
-#endif // PRECONDMANAGERFORSCH_hpp
+#endif

--- a/feddlib/problems/Solver/PreconditionerOperator.cpp
+++ b/feddlib/problems/Solver/PreconditionerOperator.cpp
@@ -1,6 +1,5 @@
-#include "PreconditionerOperator_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "PreconditionerOperator_decl.hpp"
 #include "PreconditionerOperator_def.hpp"
 namespace FEDD {
 template class PreconditionerOperator<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/Solver/PreconditionerOperator.hpp
+++ b/feddlib/problems/Solver/PreconditionerOperator.hpp
@@ -2,8 +2,8 @@
 #define PreconditionerOperator_hpp
 
 #include "PreconditionerOperator_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "Preconditioner_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "PreconditionerOperator_def.hpp"
+#endif
 
 #endif // PRECONDMANAGERFORSCH_hpp

--- a/feddlib/problems/Solver/PreconditionerOperator_def.hpp
+++ b/feddlib/problems/Solver/PreconditionerOperator_def.hpp
@@ -1,6 +1,5 @@
 #ifndef PreconditionerOperator_DEF_hpp
 #define PreconditionerOperator_DEF_hpp
-#include "PreconditionerOperator_decl.hpp"
 
 
 /*!
@@ -13,7 +12,6 @@
  */
 
 namespace FEDD {
-using namespace Thyra;
         
 // Constructors
 
@@ -48,8 +46,8 @@ void PreconditionerOperator<SC, LO, GO, NO>::beginBlockFill(
 
 template<class SC, class LO, class GO, class NO>
 void PreconditionerOperator<SC, LO, GO, NO>::beginBlockFill(
-                                                    const RCP<const ProductVectorSpaceBase<SC> > &new_productRange
-                                                    ,const RCP<const ProductVectorSpaceBase<SC> > &new_productDomain
+                                                    const Teuchos::RCP<const Thyra::ProductVectorSpaceBase<SC> > &new_productRange
+                                                    ,const Teuchos::RCP<const Thyra::ProductVectorSpaceBase<SC> > &new_productDomain
                                                     )
 {
     TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,"beginBlockFill is used but not implemented!");
@@ -77,7 +75,7 @@ bool PreconditionerOperator<SC, LO, GO, NO>::acceptsBlock(
 template<class SC, class LO, class GO, class NO>
 void PreconditionerOperator<SC, LO, GO, NO>::setNonconstBlock(
                                                       const int i, const int j
-                                                      ,const RCP<LinearOpBase<SC> > &block
+                                                      ,const Teuchos::RCP<Thyra::LinearOpBase<SC> > &block
                                                       )
 {
     setBlockImpl(i, j, block);
@@ -87,7 +85,7 @@ void PreconditionerOperator<SC, LO, GO, NO>::setNonconstBlock(
 template<class SC, class LO, class GO, class NO>
 void PreconditionerOperator<SC, LO, GO, NO>::setBlock(
                                               const int i, const int j
-                                              ,const RCP<const LinearOpBase<SC> > &block
+                                              ,const Teuchos::RCP<const Thyra::LinearOpBase<SC> > &block
                                               )
 {
     setBlockImpl(i, j, block);
@@ -191,7 +189,7 @@ void PreconditionerOperator<SC, LO, GO, NO>::uninitialize()
 
 
 template<class SC, class LO, class GO, class NO>
-Teuchos::RCP<const ProductVectorSpaceBase<SC> >
+Teuchos::RCP<const Thyra::ProductVectorSpaceBase<SC> >
 PreconditionerOperator<SC, LO, GO, NO>::productRange() const
 {
     return productRange_;
@@ -199,7 +197,7 @@ PreconditionerOperator<SC, LO, GO, NO>::productRange() const
 
 
 template<class SC, class LO, class GO, class NO>
-Teuchos::RCP<const ProductVectorSpaceBase<SC> >
+Teuchos::RCP<const Thyra::ProductVectorSpaceBase<SC> >
 PreconditionerOperator<SC, LO, GO, NO>::productDomain() const
 {
     return productDomain_;
@@ -232,7 +230,7 @@ bool PreconditionerOperator<SC, LO, GO, NO>::blockIsConst(
 
 
 template<class SC, class LO, class GO, class NO>
-Teuchos::RCP<LinearOpBase<SC> >
+Teuchos::RCP<Thyra::LinearOpBase<SC> >
 PreconditionerOperator<SC, LO, GO, NO>::getNonconstBlock(const int i, const int j)
 {
 #ifdef TEUCHOS_DEBUG
@@ -245,7 +243,7 @@ PreconditionerOperator<SC, LO, GO, NO>::getNonconstBlock(const int i, const int 
 
 
 template<class SC, class LO, class GO, class NO>
-Teuchos::RCP<const LinearOpBase<SC> >
+Teuchos::RCP<const Thyra::LinearOpBase<SC> >
 PreconditionerOperator<SC, LO, GO, NO>::getBlock(const int i, const int j) const
 {
 #ifdef TEUCHOS_DEBUG
@@ -261,7 +259,7 @@ PreconditionerOperator<SC, LO, GO, NO>::getBlock(const int i, const int j) const
 
 
 template<class SC, class LO, class GO, class NO>
-Teuchos::RCP< const VectorSpaceBase<SC> >
+Teuchos::RCP< const Thyra::VectorSpaceBase<SC> >
 PreconditionerOperator<SC, LO, GO, NO>::range() const
 {
     return productRange_;
@@ -269,7 +267,7 @@ PreconditionerOperator<SC, LO, GO, NO>::range() const
 
 
 template<class SC, class LO, class GO, class NO>
-Teuchos::RCP< const VectorSpaceBase<SC> >
+Teuchos::RCP< const Thyra::VectorSpaceBase<SC> >
 PreconditionerOperator<SC, LO, GO, NO>::domain() const
 {
     return productDomain_;
@@ -277,7 +275,7 @@ PreconditionerOperator<SC, LO, GO, NO>::domain() const
 
 
 template<class SC, class LO, class GO, class NO>
-Teuchos::RCP<const LinearOpBase<SC> >
+Teuchos::RCP<const Thyra::LinearOpBase<SC> >
 PreconditionerOperator<SC, LO, GO, NO>::clone() const
 {
     return Teuchos::null; // ToDo: Implement this when needed!
@@ -311,7 +309,7 @@ void PreconditionerOperator<SC, LO, GO, NO>::describe(
     using Teuchos::FancyOStream;
     using Teuchos::OSTab;
     assertBlockFillIsActive(false);
-    RCP<FancyOStream> out = rcpFromRef(out_arg);
+    Teuchos::RCP<FancyOStream> out = rcpFromRef(out_arg);
     OSTab tab1(out);
     switch(verbLevel) {
         case Teuchos::VERB_DEFAULT:
@@ -337,7 +335,7 @@ void PreconditionerOperator<SC, LO, GO, NO>::describe(
             for( int i = 0; i < numRowBlocks_; ++i ) {
                 for( int j = 0; j < numColBlocks_; ++j ) {
                     *out << "Op["<<i<<","<<j<<"] = ";
-                    RCP<const LinearOpBase<SC> >
+                    Teuchos::RCP<const Thyra::LinearOpBase<SC> >
                     block_i_j = getBlock(i,j);
                     if(block_i_j.get())
                         *out << Teuchos::describe(*getBlock(i,j),verbLevel);
@@ -360,12 +358,12 @@ void PreconditionerOperator<SC, LO, GO, NO>::describe(
 
 
 template<class SC, class LO, class GO, class NO>
-bool PreconditionerOperator<SC, LO, GO, NO>::opSupportedImpl(EOpTransp M_trans) const
+bool PreconditionerOperator<SC, LO, GO, NO>::opSupportedImpl(Thyra::EOpTransp M_trans) const
 {
     bool supported = true;
     for( int i = 0; i < numRowBlocks_; ++i ) {
         for( int j = 0; j < numColBlocks_; ++j ) {
-            RCP<const LinearOpBase<SC> >
+            Teuchos::RCP<const Thyra::LinearOpBase<SC> >
             block_i_j = getBlock(i,j);
             if( block_i_j.get() && !Thyra::opSupported(*block_i_j,M_trans) )
                 supported = false;
@@ -441,7 +439,7 @@ void PreconditionerOperator<SC, LO, GO, NO>::assertBlockRowCol(
 
 template<class SC, class LO, class GO, class NO>
 void PreconditionerOperator<SC, LO, GO, NO>::setBlockSpaces(
-                                                    const int i, const int j, const LinearOpBase<SC> &block
+                                                    const int i, const int j, const Thyra::LinearOpBase<SC> &block
                                                     )
 {
     using Teuchos::toString;
@@ -452,7 +450,7 @@ void PreconditionerOperator<SC, LO, GO, NO>::setBlockSpaces(
     // compatible with the block that is being set.
     if( i < numRowBlocks_ && j < numColBlocks_ ) {
 #ifdef TEUCHOS_DEBUG
-        RCP<const VectorSpaceBase<SC> >
+        Teuchos::RCP<const Thyra::VectorSpaceBase<SC> >
         rangeBlock = (
                       productRange_.get()
                       ? productRange_->getBlock(i)
@@ -512,7 +510,7 @@ template<class SC, class LO, class GO, class NO>
 template<class LinearOpType>
 void PreconditionerOperator<SC, LO, GO, NO>::setBlockImpl(
                                                   const int i, const int j,
-                                                  const RCP<LinearOpType> &block
+                                                  const Teuchos::RCP<LinearOpType> &block
                                                   )
 {
     setBlockSpaces(i, j, *block);
@@ -561,12 +559,12 @@ void PreconditionerOperator<SC, LO, GO, NO>::adjustBlockSpaces()
     // Adjust blocks in the range space
     for (int i = 0; i < numRowBlocks_; ++i) {
         for (int j = 0; j < numColBlocks_; ++j) {
-            const RCP<const LinearOpBase<SC> >
+            const Teuchos::RCP<const Thyra::LinearOpBase<SC> >
             op_i_j = Ops_[numRowBlocks_*j+i];
             if (is_null(op_i_j))
                 continue;
-            const RCP<const VectorSpaceBase<SC> > range_i_j = op_i_j->range();
-            if (is_null(productVectorSpaceBase<SC>(range_i_j, false))) {
+            const Teuchos::RCP<const Thyra::VectorSpaceBase<SC> > range_i_j = op_i_j->range();
+            if (is_null(Thyra::productVectorSpaceBase<SC>(range_i_j, false))) {
                 rangeBlocks_[i] = range_i_j;
                 break;
             }
@@ -576,13 +574,13 @@ void PreconditionerOperator<SC, LO, GO, NO>::adjustBlockSpaces()
     // Adjust blocks in the domain space
     for (int j = 0; j < numColBlocks_; ++j) {
         for (int i = 0; i < numRowBlocks_; ++i) {
-            const RCP<const LinearOpBase<SC> >
+            const Teuchos::RCP<const Thyra::LinearOpBase<SC> >
             op_i_j = Ops_[numRowBlocks_*j+i];
             if (is_null(op_i_j))
                 continue;
-            const RCP<const VectorSpaceBase<SC> >
+            const Teuchos::RCP<const Thyra::VectorSpaceBase<SC> >
             domain_i_j = op_i_j->domain();
-            if (is_null(productVectorSpaceBase<SC>(domain_i_j, false))) {
+            if (is_null(Thyra::productVectorSpaceBase<SC>(domain_i_j, false))) {
                 domainBlocks_[j] = domain_i_j;
                 break;
             }

--- a/feddlib/problems/Solver/Preconditioner_decl.hpp
+++ b/feddlib/problems/Solver/Preconditioner_decl.hpp
@@ -1,23 +1,17 @@
 #ifndef Preconditioner_DECL_hpp
 #define Preconditioner_DECL_hpp
 
-#include "feddlib/problems/problems_config.h"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-#include "feddlib/core/General/ExporterParaView.hpp"
-#include "feddlib/problems/abstract/MinPrecProblem.hpp"
-#include "feddlib/problems/abstract/Problem.hpp"
-#include "feddlib/problems/abstract/TimeProblem.hpp"
-#include "feddlib/problems/Solver/PrecOpFaCSI.hpp"
-#include "feddlib/problems/Solver/PrecBlock2x2.hpp"
-#include "feddlib/problems/specific/LaplaceBlocks.hpp"
-#include "feddlib/problems/specific/FSI.hpp"
-#include "Xpetra_ThyraUtils.hpp"
+#include <Xpetra_ThyraUtils.hpp>
 #include <Thyra_PreconditionerBase.hpp>
 #include <Thyra_DefaultPreconditioner_decl.hpp>
 #include <Stratimikos_FROSch_def.hpp>
-//#include <Stratimikos_FROSch_def.hpp> // hier werden schon alle FROSch VK eingebunden
+
+#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include "feddlib/core/General/ExporterParaView.hpp"
+#include "feddlib/problems/problems_config.h"
+
 #ifdef FEDD_HAVE_TEKO
-#include "Teko_StratimikosFactory.hpp"
+#include <Teko_StratimikosFactory.hpp>
 #include <Teko_StaticRequestCallback.hpp>
 #endif
 

--- a/feddlib/problems/Solver/Preconditioner_def.hpp
+++ b/feddlib/problems/Solver/Preconditioner_def.hpp
@@ -8,11 +8,24 @@
 
 #ifndef Preconditioner_DEF_hpp
 #define Preconditioner_DEF_hpp
-#include "Preconditioner_decl.hpp"
 #include <Thyra_DefaultZeroLinearOp_decl.hpp>
 #ifdef FEDD_HAVE_IFPACK2
 #include <Thyra_Ifpack2PreconditionerFactory_def.hpp>
 #endif
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+
+#include "feddlib/problems/abstract/MinPrecProblem.hpp"
+#include "feddlib/problems/abstract/Problem.hpp"
+#include "feddlib/problems/abstract/TimeProblem.hpp"
+#include "feddlib/problems/specific/NavierStokes.hpp"
+#include "feddlib/problems/specific/NonLinElasticity.hpp"
+#include "feddlib/problems/specific/LinElas.hpp"
+#include "feddlib/problems/specific/Geometry.hpp"
+#include "feddlib/problems/specific/FSI.hpp"
+#include "feddlib/problems/Solver/PrecOpFaCSI.hpp"
+#include "feddlib/problems/Solver/PrecBlock2x2.hpp"
 
 /*!
  Definition of Preconditioner

--- a/feddlib/problems/Solver/TimeSteppingTools.cpp
+++ b/feddlib/problems/Solver/TimeSteppingTools.cpp
@@ -1,4 +1,6 @@
 #include "TimeSteppingTools.hpp"
+#include "feddlib/core/General/ExporterParaView.hpp"
+
 /*!
  Definition of TimeSteppingTools
  

--- a/feddlib/problems/Solver/TimeSteppingTools.hpp
+++ b/feddlib/problems/Solver/TimeSteppingTools.hpp
@@ -1,9 +1,9 @@
 #ifndef TIMESTEPPINGTOOLS_hpp
 #define TIMESTEPPINGTOOLS_hpp
 
-#include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/problems/problems_config.h"
-#include "feddlib/core/General/ExporterParaView.hpp"
+#include "feddlib/core/FEDDCore.hpp"
+
 #include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
 #include "feddlib/core/General/ExporterTxt.hpp"
 

--- a/feddlib/problems/abstract/LinearProblem.cpp
+++ b/feddlib/problems/abstract/LinearProblem.cpp
@@ -1,5 +1,5 @@
-#include "LinearProblem_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "LinearProblem_decl.hpp"
 #include "LinearProblem_def.hpp"
 namespace FEDD {
     template class LinearProblem<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/abstract/LinearProblem.hpp
+++ b/feddlib/problems/abstract/LinearProblem.hpp
@@ -2,8 +2,8 @@
 #define LINEARPROBLEM_hpp
 
 #include "LinearProblem_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "LinearProblem_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "LinearProblem_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/abstract/LinearProblem_def.hpp
+++ b/feddlib/problems/abstract/LinearProblem_def.hpp
@@ -1,6 +1,5 @@
 #ifndef LINEARPROBLEM_DEF_hpp
 #define LINEARPROBLEM_DEF_hpp
-#include "LinearProblem_decl.hpp"
 
 /*!
  Definition of LinearProblem

--- a/feddlib/problems/abstract/MinPrecProblem.cpp
+++ b/feddlib/problems/abstract/MinPrecProblem.cpp
@@ -1,5 +1,5 @@
-#include "MinPrecProblem_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "MinPrecProblem_decl.hpp"
 #include "MinPrecProblem_def.hpp"
 namespace FEDD{
     template class MinPrecProblem<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/abstract/MinPrecProblem.hpp
+++ b/feddlib/problems/abstract/MinPrecProblem.hpp
@@ -2,8 +2,8 @@
 #define MinPrecProblem_hpp
 
 #include "MinPrecProblem_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "MinPrecProblem_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "MinPrecProblem_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/abstract/MinPrecProblem_decl.hpp
+++ b/feddlib/problems/abstract/MinPrecProblem_decl.hpp
@@ -22,6 +22,7 @@ template <class SC , class LO , class GO , class NO >
 class Problem;
 template <class SC , class LO , class GO , class NO >
 class Preconditioner;
+
 template <class SC = default_sc, class LO = default_lo, class GO = default_go, class NO = default_no>
 class MinPrecProblem : public Problem<SC,LO,GO,NO> {
 

--- a/feddlib/problems/abstract/MinPrecProblem_def.hpp
+++ b/feddlib/problems/abstract/MinPrecProblem_def.hpp
@@ -1,6 +1,7 @@
 #ifndef MinPrecProblem_DEF_hpp
 #define MinPrecProblem_DEF_hpp
-#include "MinPrecProblem_decl.hpp"
+
+#include "feddlib/problems/Solver/Preconditioner.hpp"
 
 /*!
  Definition of MinPrecProblem

--- a/feddlib/problems/abstract/NonLinearProblem.cpp
+++ b/feddlib/problems/abstract/NonLinearProblem.cpp
@@ -1,5 +1,5 @@
-#include "NonLinearProblem_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "NonLinearProblem_decl.hpp"
 #include "NonLinearProblem_def.hpp"
 namespace FEDD{
     template class NonLinearProblem<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/abstract/NonLinearProblem.hpp
+++ b/feddlib/problems/abstract/NonLinearProblem.hpp
@@ -3,8 +3,8 @@
 
 #include "NonLinearProblem_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "NonLinearProblem_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "NonLinearProblem_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/abstract/NonLinearProblem_decl.hpp
+++ b/feddlib/problems/abstract/NonLinearProblem_decl.hpp
@@ -1,9 +1,12 @@
 #ifndef NONLINEARPROBLEM_DECL_hpp
 #define NONLINEARPROBLEM_DECL_hpp
 
-#include "Problem.hpp"
 #include <Thyra_StateFuncModelEvaluatorBase.hpp>
+#include <Thyra_ProductVectorBase.hpp>
+#include <Teko_Utilities.hpp>
 
+#include "feddlib/core/FEDDCore.hpp"
+#include "feddlib/problems/abstract/Problem.hpp"
 
 /*!
  Declaration of NonLinearProblem
@@ -15,10 +18,8 @@
  */
 
 namespace FEDD{
-template<class SC_, class LO_, class GO_, class NO_>
-class Problem;
-template<class SC_, class LO_, class GO_, class NO_>
-class TimeProblem;
+template<class LO_, class GO_, class NO_>
+class BlockMap;
 
 template <class SC = default_sc,
           class LO = default_lo,
@@ -55,12 +56,14 @@ public:
     typedef Teuchos::RCP<const BlockMap_Type> BlockMapConstPtr_Type;
     typedef Teuchos::Array<BlockMultiVectorPtr_Type> BlockMultiVectorPtrArray_Type;
 
-    typedef Thyra::VectorSpaceBase<SC> ThyraVecSpace_Type;
+    using ThyraTypes = ThyraTypedefs<SC>;
+    using TpetraTypes = TpetraTypedefs<SC,LO,GO,NO>;
+    using ThyraVecSpace_Type = typename ThyraTypes::ThyraVecSpace_Type;
     typedef Teuchos::RCP<const ThyraVecSpace_Type> ThyraVecSpaceConstPtr_Type;
-    typedef Thyra::VectorBase<SC> ThyraVec_Type;
-    typedef Tpetra::CrsMatrix<SC, LO, GO, NO> TpetraMatrix_Type;
-    typedef Thyra::LinearOpBase<SC> ThyraOp_Type;
-    typedef Tpetra::Operator<SC,LO,GO,NO> TpetraOp_Type;
+    using ThyraVec_Type = typename ThyraTypes::ThyraVec_Type;
+    using TpetraMatrix_Type = typename TpetraTypes::TpetraMatrix_Type;
+    using ThyraOp_Type = typename ThyraTypes::ThyraOp_Type;
+    using TpetraOp_Type = typename TpetraTypes::TpetraOp_Type;
     typedef Thyra::BlockedLinearOpBase<SC> ThyraBlockOp_Type;
 
     /// @brief Constructor

--- a/feddlib/problems/abstract/NonLinearProblem_def.hpp
+++ b/feddlib/problems/abstract/NonLinearProblem_def.hpp
@@ -1,7 +1,11 @@
 #ifndef NONLINEARPROBLEM_DEF_hpp
 #define NONLINEARPROBLEM_DEF_hpp
-#include "NonLinearProblem_decl.hpp"
-#include "TimeProblem.hpp"
+
+#include "Problem.hpp"
+#include "feddlib/core/LinearAlgebra/BlockMap.hpp"
+#include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
 
 /*!
  Definition of NonLinearProblem

--- a/feddlib/problems/abstract/Problem.cpp
+++ b/feddlib/problems/abstract/Problem.cpp
@@ -1,5 +1,5 @@
-#include "Problem_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Problem_decl.hpp"
 #include "Problem_def.hpp"
 namespace FEDD{
     template class Problem<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/abstract/Problem.hpp
+++ b/feddlib/problems/abstract/Problem.hpp
@@ -2,8 +2,8 @@
 #define PROBLEM_hpp
 
 #include "Problem_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "Problem_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Problem_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/abstract/Problem_decl.hpp
+++ b/feddlib/problems/abstract/Problem_decl.hpp
@@ -1,26 +1,18 @@
 #ifndef PROBLEM_DECL_hpp
 #define PROBLEM_DECL_hpp
 
-#include "feddlib/problems/problems_config.h"
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/FE/FE.hpp"
-#include "feddlib/core/FE/Domain.hpp"
-#include "feddlib/core/General/BCBuilder.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-#include "feddlib/problems/Solver/Preconditioner.hpp"
-#include "feddlib/core/LinearAlgebra/BlockMultiVector.hpp"
-#include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
-#include "feddlib/problems/Solver/LinearSolver.hpp"
-
 #include <Stratimikos_DefaultLinearSolverBuilder.hpp>
 #include <Thyra_PreconditionerBase.hpp>
-#include <Thyra_LinearOpBase_decl.hpp>
 
 #include "git_version.h"
 
 #ifdef FEDD_HAVE_TEKO
 #include <Teko_StratimikosFactory.hpp>
 #endif
+
+#include "feddlib/problems/problems_config.h"
+#include "feddlib/core/FEDDCore.hpp"
+#include "feddlib/core/LinearAlgebra/Matrix.hpp"
 
 /*!
  Declaration of Problem
@@ -33,6 +25,16 @@
 
 
 namespace FEDD {
+template<class SC_, class LO_, class GO_, class NO_>
+class BlockMultiVector;
+template<class SC_, class LO_, class GO_, class NO_>
+class BCBuilder;
+template<class SC_, class LO_, class GO_, class NO_>
+class BlockMatrix;
+template<class SC_, class LO_, class GO_, class NO_>
+class Domain;
+template<class SC_, class LO_, class GO_, class NO_>
+class FE;
 template<class SC_, class LO_, class GO_, class NO_>
 class Preconditioner;
 
@@ -91,8 +93,9 @@ public:
     typedef std::vector<std::string> string_vec_Type;
 
     typedef Teuchos::RCP<Thyra::PreconditionerBase<SC> > ThyraPrecPtr_Type;
-    typedef Teuchos::RCP<Thyra::LinearOpBase<SC> > ThyraLinOpPtr_Type;
-    
+    using ThyraTypes = ThyraTypedefs<SC>;
+    using ThyraLinOpPtr_Type = Teuchos::RCP<typename ThyraTypes::ThyraOp_Type>;
+
     Problem(CommConstPtr_Type comm);
 
     Problem(ParameterListPtr_Type &parameterList, CommConstPtr_Type comm);

--- a/feddlib/problems/abstract/Problem_def.hpp
+++ b/feddlib/problems/abstract/Problem_def.hpp
@@ -1,6 +1,13 @@
 #ifndef PROBLEM_DEF_hpp
 #define PROBLEM_DEF_hpp
-#include "Problem_decl.hpp"
+
+#include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/FE/FE.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
+#include "feddlib/problems/Solver/LinearSolver.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+#include "feddlib/core/LinearAlgebra/BlockMultiVector.hpp"
 
 /*!
  Definition of Problem
@@ -10,10 +17,6 @@
  @copyright CH
  */
 
-using Teuchos::outArg;
-using Teuchos::REDUCE_MAX;
-using Teuchos::REDUCE_SUM;
-using Teuchos::reduceAll;
 
 namespace FEDD
 {
@@ -594,7 +597,7 @@ namespace FEDD
         {
             result += vector[i] * outputVector[i];
         }
-        reduceAll<int, double>(*comm_, REDUCE_SUM, result, outArg(result));
+        Teuchos::reduceAll<int, double>(*comm_, Teuchos::REDUCE_SUM, result, Teuchos::outArg(result));
 
         return result;
     }
@@ -616,7 +619,7 @@ namespace FEDD
         {
             result += vector[i] * outputVector[i];
         }
-        reduceAll<int, double>(*comm_, REDUCE_SUM, result, outArg(result));
+        Teuchos::reduceAll<int, double>(*comm_, Teuchos::REDUCE_SUM, result, Teuchos::outArg(result));
 
         return result;
     }

--- a/feddlib/problems/abstract/TimeProblem.cpp
+++ b/feddlib/problems/abstract/TimeProblem.cpp
@@ -1,7 +1,6 @@
-#include "TimeProblem_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "TimeProblem_decl.hpp"
 #include "TimeProblem_def.hpp"
-//    template class Problem<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
 namespace FEDD {
     template class TimeProblem<default_sc, default_lo, default_go, default_no>;
 }

--- a/feddlib/problems/abstract/TimeProblem.hpp
+++ b/feddlib/problems/abstract/TimeProblem.hpp
@@ -2,8 +2,8 @@
 #define TIMEPROBLEM_hpp
 
 #include "TimeProblem_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-//     #include "TimeProblem_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "TimeProblem_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/abstract/TimeProblem_decl.hpp
+++ b/feddlib/problems/abstract/TimeProblem_decl.hpp
@@ -3,11 +3,10 @@
 
 #include "feddlib/problems/problems_config.h"
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-#include "feddlib/problems/Solver/Preconditioner.hpp"
-#include "NonLinearProblem.hpp"
-//#include "LinearProblem.hpp"
+#include "Problem.hpp"
+
 #include <Thyra_StateFuncModelEvaluatorBase.hpp>
+
 /*!
  Declaration of TimeProblem
 
@@ -24,11 +23,10 @@
  */
 namespace FEDD {
 template<class SC_, class LO_, class GO_, class NO_>
-class NonLinearProblem;
-template<class SC_, class LO_, class GO_, class NO_>
-//class LinearProblem;
-//template<class SC_, class LO_, class GO_, class NO_>
 class Preconditioner;
+template<class SC_, class LO_, class GO_, class NO_>
+class NonLinearProblem;
+
 template <class SC = default_sc, class LO = default_lo, class GO = default_go, class NO = default_no>
 class TimeProblem: public Thyra::StateFuncModelEvaluatorBase<SC>  {
 
@@ -74,14 +72,16 @@ public:
 
     typedef typename Problem_Type::LinSolverBuilderPtr_Type LinSolverBuilderPtr_Type;
 
-    typedef typename NonLinProb_Type::TpetraMatrix_Type TpetraMatrix_Type;
-    
-    typedef typename NonLinProb_Type::ThyraVecSpace_Type ThyraVecSpace_Type;
-    typedef typename NonLinProb_Type::ThyraVec_Type ThyraVec_Type;
-    typedef typename NonLinProb_Type::ThyraOp_Type ThyraOp_Type;
+    using TpetraTypes = TpetraTypedefs<SC,LO,GO,NO>;
+    using TpetraMatrix_Type = typename TpetraTypes::TpetraMatrix_Type;
+    using TpetraOp_Type = typename TpetraTypes::TpetraOp_Type;
+
+    using ThyraTypes = ThyraTypedefs<SC>;
+    using ThyraVecSpace_Type = typename ThyraTypes::ThyraVecSpace_Type;
+    using ThyraVec_Type = typename ThyraTypes::ThyraVec_Type;
     typedef Thyra::BlockedLinearOpBase<SC> ThyraBlockOp_Type;
-    
-    typedef typename NonLinProb_Type::TpetraOp_Type TpetraOp_Type;
+
+    using ThyraOp_Type = typename ThyraTypes::ThyraOp_Type;    
         
     TimeProblem(Problem_Type& problem, CommConstPtr_Type comm);
     

--- a/feddlib/problems/abstract/TimeProblem_def.hpp
+++ b/feddlib/problems/abstract/TimeProblem_def.hpp
@@ -1,6 +1,16 @@
 #ifndef TIMEPROBLEM_DEF_hpp
 #define TIMEPROBLEM_DEF_hpp
-#include "TimeProblem_decl.hpp"
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/FE/FE.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+
+#include "NonLinearProblem.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
+#include "feddlib/problems/Solver/LinearSolver.hpp"
+#include "feddlib/problems/specific/FSI.hpp"
+
+
 /*!
  Definition of TimeProblem
 

--- a/feddlib/problems/examples/fsi/main.cpp
+++ b/feddlib/problems/examples/fsi/main.cpp
@@ -1,18 +1,21 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/core/General/HDF5Import.hpp"
-
+#include "feddlib/problems/specific/Geometry.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
 
 #include "feddlib/problems/specific/FSI.hpp"
 #include "feddlib/problems/Solver/DAESolverInTime.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
+#include "feddlib/problems/specific/NavierStokes.hpp"
+#include "feddlib/problems/specific/LinElas.hpp"
+#include "feddlib/problems/specific/NonLinElasticity.hpp"
 
 void rhsDummy2D(double* x, double* res, double* parameters){
     // parameters[0] is the time, not needed here

--- a/feddlib/problems/examples/fsi_artery/main.cpp
+++ b/feddlib/problems/examples/fsi_artery/main.cpp
@@ -1,18 +1,23 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/General/HDF5Import.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 
 #include "feddlib/problems/specific/FSI.hpp"
 #include "feddlib/problems/specific/Laplace.hpp"
+#include "feddlib/problems/specific/NavierStokes.hpp"
+#include "feddlib/problems/specific/LinElas.hpp"
+#include "feddlib/problems/specific/NonLinElasticity.hpp"
+#include "feddlib/problems/specific/Geometry.hpp"
 #include "feddlib/problems/Solver/DAESolverInTime.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
+
 
 /*! Test case for specific artery geometrie or straight tube geometry. Inflow depends on inflow region
 	-> straight tube: Inflow in (0,0,z)*laplaceInflow direction

--- a/feddlib/problems/examples/fsi_arteryBenchmark/main.cpp
+++ b/feddlib/problems/examples/fsi_arteryBenchmark/main.cpp
@@ -1,20 +1,22 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/core/General/HDF5Import.hpp"
-
-#include "feddlib/problems/specific/FSI.hpp"
+#include "feddlib/core/General/HDF5Export.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/problems/specific/Laplace.hpp"
+#include "feddlib/problems/specific/LinElas.hpp"
+#include "feddlib/problems/specific/NonLinElasticity.hpp"
+#include "feddlib/problems/specific/NavierStokes.hpp"
+#include "feddlib/problems/specific/Geometry.hpp"
+#include "feddlib/problems/specific/FSI.hpp"
 #include "feddlib/problems/Solver/DAESolverInTime.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
-
-#include "feddlib/core/General/HDF5Export.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
 
 
 /*! Test case for the curved artery gemeotry proposed in 

--- a/feddlib/problems/examples/geometry/main.cpp
+++ b/feddlib/problems/examples/geometry/main.cpp
@@ -1,16 +1,13 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/problems/specific/Geometry.hpp"
 #include "feddlib/problems/specific/LinElas.hpp"
-
 
 void geometryBC2D(double* x, double* res, double t, const double* parameters)
 {

--- a/feddlib/problems/examples/laplace/main.cpp
+++ b/feddlib/problems/examples/laplace/main.cpp
@@ -1,13 +1,12 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/General/HDF5Export.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/problems/specific/Laplace.hpp"
 
 /*!

--- a/feddlib/problems/examples/steadyGeneralizedNewtonian_PowerLaw/main.cpp
+++ b/feddlib/problems/examples/steadyGeneralizedNewtonian_PowerLaw/main.cpp
@@ -9,8 +9,7 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"

--- a/feddlib/problems/examples/steadyLinElas/main.cpp
+++ b/feddlib/problems/examples/steadyLinElas/main.cpp
@@ -1,8 +1,7 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"

--- a/feddlib/problems/examples/steadyLinElas_Perf/main.cpp
+++ b/feddlib/problems/examples/steadyLinElas_Perf/main.cpp
@@ -2,8 +2,7 @@
 #include <Teuchos_StackedTimer.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"

--- a/feddlib/problems/examples/steadyNavierStokes/main.cpp
+++ b/feddlib/problems/examples/steadyNavierStokes/main.cpp
@@ -1,8 +1,10 @@
 #include <Tpetra_Core.hpp>
 
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_StackedTimer.hpp>
 
+#include "feddlib/core/FEDDCore.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
@@ -10,10 +12,6 @@
 
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
 #include "feddlib/problems/specific/NavierStokes.hpp"
-
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_StackedTimer.hpp>
-
 
 /*!
  main of steady-state Navier-Stokes problem

--- a/feddlib/problems/examples/stokes/main.cpp
+++ b/feddlib/problems/examples/stokes/main.cpp
@@ -2,8 +2,7 @@
 #include <Teuchos_TestForException.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"

--- a/feddlib/problems/examples/unsteadyLinElas/main.cpp
+++ b/feddlib/problems/examples/unsteadyLinElas/main.cpp
@@ -17,8 +17,7 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"

--- a/feddlib/problems/examples/unsteadyNavierStokes/main.cpp
+++ b/feddlib/problems/examples/unsteadyNavierStokes/main.cpp
@@ -1,19 +1,17 @@
 #include <Tpetra_Core.hpp>
 
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Teuchos_StackedTimer.hpp>
 
+#include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/problems/Solver/DAESolverInTime.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
 #include "feddlib/problems/specific/NavierStokes.hpp"
-
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_StackedTimer.hpp>
 
 /*!
  main of time-dependent Navier-Stokes problem

--- a/feddlib/problems/examples/unsteadyNonLinElasticity/main.cpp
+++ b/feddlib/problems/examples/unsteadyNonLinElasticity/main.cpp
@@ -1,8 +1,7 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"

--- a/feddlib/problems/examples/unsteadyReactionDiffusion/main.cpp
+++ b/feddlib/problems/examples/unsteadyReactionDiffusion/main.cpp
@@ -1,8 +1,7 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"

--- a/feddlib/problems/specific/DiffusionReaction.cpp
+++ b/feddlib/problems/specific/DiffusionReaction.cpp
@@ -1,7 +1,6 @@
-#include "DiffusionReaction_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "DiffusionReaction_decl.hpp"
 #include "DiffusionReaction_def.hpp"
-//template class Diffusion<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
 namespace FEDD {
 template class DiffusionReaction<default_sc, default_lo, default_go, default_no>;
 }

--- a/feddlib/problems/specific/DiffusionReaction.hpp
+++ b/feddlib/problems/specific/DiffusionReaction.hpp
@@ -2,8 +2,8 @@
 #define DIFFUSIONREACTION_hpp
 
 #include "DiffusionReaction_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "DiffusionReaction_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "DiffusionReaction_def.hpp"
+#endif
 
 #endif // DiffusionReaction_hpp

--- a/feddlib/problems/specific/DiffusionReaction_decl.hpp
+++ b/feddlib/problems/specific/DiffusionReaction_decl.hpp
@@ -1,5 +1,7 @@
 #ifndef DIFFUSION_decl_hpp
 #define DIFFUSION_decl_hpp
+
+#include "feddlib/problems/abstract/Problem.hpp"
 #include "feddlib/problems/abstract/NonLinearProblem.hpp"
 #include <Thyra_ProductVectorBase.hpp>
 #include <Thyra_PreconditionerBase.hpp>

--- a/feddlib/problems/specific/DiffusionReaction_def.hpp
+++ b/feddlib/problems/specific/DiffusionReaction_def.hpp
@@ -1,6 +1,6 @@
 #ifndef DIFFUSIONREACTION_def_hpp
 #define DIFFUSIONREACTION_def_hpp
-#include "DiffusionReaction_decl.hpp"
+
 /*!
  Definition of Diffusion Reaction Equation
  
@@ -9,6 +9,10 @@
  @version 1.0
  @copyright LS
  */
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/FE/FE.hpp"
+
 
 namespace FEDD {
 

--- a/feddlib/problems/specific/FSI.cpp
+++ b/feddlib/problems/specific/FSI.cpp
@@ -1,6 +1,5 @@
-#include "FSI_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "FSI_decl.hpp"
 #include "FSI_def.hpp"
 namespace FEDD {
     template class FSI<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/specific/FSI.hpp
+++ b/feddlib/problems/specific/FSI.hpp
@@ -3,8 +3,8 @@
 
 #include "FSI_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "FSI_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "FSI_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/specific/FSI_decl.hpp
+++ b/feddlib/problems/specific/FSI_decl.hpp
@@ -1,13 +1,14 @@
 #ifndef FSI_decl_hpp
 #define FSI_decl_hpp
-#include "feddlib/problems/abstract/TimeProblem.hpp"
-#include "feddlib/problems/specific/NavierStokes.hpp"
-#include "feddlib/problems/specific/LinElas.hpp"
-#include "feddlib/problems/specific/NonLinElasticity.hpp"
-#include "feddlib/problems/specific/Geometry.hpp"
+
+#include "feddlib/problems/abstract/Problem.hpp"
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/problems/abstract/NonLinearProblem.hpp"
 #include "feddlib/problems/Solver/TimeSteppingTools.hpp"
+
 #include <Thyra_PreconditionerBase.hpp>
 #include <Thyra_ModelEvaluatorBase_decl.hpp>
+
 namespace FEDD{
 
 template <class SC , class LO , class GO , class NO >
@@ -20,6 +21,10 @@ template <class SC , class LO , class GO , class NO >
 class LinElas;
 template <class SC , class LO , class GO , class NO >
 class NonLinElasticity;
+template <class SC , class LO , class GO , class NO >
+class MeshUnstructured;
+template <class SC , class LO , class GO , class NO >
+class ExporterParaView;
 
 template <class SC = default_sc, class LO = default_lo, class GO = default_go, class NO = default_no>
 class FSI : public NonLinearProblem<SC,LO,GO,NO>  {

--- a/feddlib/problems/specific/FSI_def.hpp
+++ b/feddlib/problems/specific/FSI_def.hpp
@@ -1,6 +1,18 @@
 #ifndef FSI_def_hpp
 #define FSI_def_hpp
-#include "FSI_decl.hpp"
+
+#include "feddlib/problems/abstract/TimeProblem.hpp"
+#include "feddlib/problems/specific/NavierStokes.hpp"
+#include "feddlib/problems/specific/LinElas.hpp"
+#include "feddlib/problems/specific/NonLinElasticity.hpp"
+#include "feddlib/problems/specific/Geometry.hpp"
+#include "feddlib/core/Mesh/MeshUnstructured.hpp"
+#include "feddlib/core/General/ExporterParaView.hpp"
+#include "feddlib//core/FE/FE.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+
+
+// TODO: [JK] Why are all these functions in the global namespace?
 
 double OneFunc(double* x, int* parameter)
 {

--- a/feddlib/problems/specific/Geometry.cpp
+++ b/feddlib/problems/specific/Geometry.cpp
@@ -1,6 +1,5 @@
-#include "Geometry_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Geometry_decl.hpp"
 #include "Geometry_def.hpp"
 namespace FEDD {
     template class Geometry<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/specific/Geometry.hpp
+++ b/feddlib/problems/specific/Geometry.hpp
@@ -3,8 +3,8 @@
 
 #include "Geometry_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "Geometry_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Geometry_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/specific/Geometry_def.hpp
+++ b/feddlib/problems/specific/Geometry_def.hpp
@@ -1,6 +1,9 @@
 #ifndef GEOMETRY_def_hpp
 #define GEOMETRY_def_hpp
-#include "Geometry_decl.hpp"
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/FE/FE.hpp"
+
 namespace FEDD {
 // Funktion fuer die rechte Seite der DGL in 2D
 void ZeroFErhsFunc2D(double* x, double* result, double* parameters)

--- a/feddlib/problems/specific/Laplace.cpp
+++ b/feddlib/problems/specific/Laplace.cpp
@@ -1,7 +1,6 @@
-#include "Laplace_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Laplace_decl.hpp"
 #include "Laplace_def.hpp"
-//template class Laplace<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
 namespace FEDD {
 template class Laplace<default_sc, default_lo, default_go, default_no>;
 }

--- a/feddlib/problems/specific/Laplace.hpp
+++ b/feddlib/problems/specific/Laplace.hpp
@@ -2,8 +2,8 @@
 #define LAPLACE_hpp
 
 #include "Laplace_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "Laplace_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Laplace_def.hpp"
+#endif
 
 #endif // LAPLACE_hpp

--- a/feddlib/problems/specific/LaplaceBlocks.cpp
+++ b/feddlib/problems/specific/LaplaceBlocks.cpp
@@ -1,7 +1,6 @@
-#include "LaplaceBlocks_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "LaplaceBlocks_decl.hpp"
 #include "LaplaceBlocks_def.hpp"
-//template class LaplaceBlocks<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
 namespace FEDD {
 template class LaplaceBlocks<default_sc, default_lo, default_go, default_no>;
 }

--- a/feddlib/problems/specific/LaplaceBlocks.hpp
+++ b/feddlib/problems/specific/LaplaceBlocks.hpp
@@ -2,8 +2,8 @@
 #define LaplaceBlocks_hpp
 
 #include "LaplaceBlocks_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "LaplaceBlocks_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "LaplaceBlocks_def.hpp"
+#endif
 
 #endif // LaplaceBlocks_hpp

--- a/feddlib/problems/specific/LaplaceBlocks_def.hpp
+++ b/feddlib/problems/specific/LaplaceBlocks_def.hpp
@@ -1,6 +1,6 @@
 #ifndef LaplaceBlocks_def_hpp
 #define LaplaceBlocks_def_hpp
-#include "LaplaceBlocks_decl.hpp"
+
 /*!
  Definition of LaplaceBlocks
  
@@ -9,6 +9,10 @@
  @version 1.0
  @copyright CH
  */
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/FE/FE.hpp"
+
 
 namespace FEDD {
 

--- a/feddlib/problems/specific/Laplace_def.hpp
+++ b/feddlib/problems/specific/Laplace_def.hpp
@@ -1,6 +1,6 @@
 #ifndef LAPLACE_def_hpp
 #define LAPLACE_def_hpp
-#include "Laplace_decl.hpp"
+
 /*!
  Definition of Laplace
  
@@ -9,6 +9,9 @@
  @version 1.0
  @copyright CH
  */
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/FE/FE.hpp"
 
 namespace FEDD {
 

--- a/feddlib/problems/specific/LinElas.cpp
+++ b/feddlib/problems/specific/LinElas.cpp
@@ -1,6 +1,5 @@
-#include "LinElas_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "LinElas_decl.hpp"
 #include "LinElas_def.hpp"
 namespace FEDD {
     template class LinElas<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/specific/LinElas.hpp
+++ b/feddlib/problems/specific/LinElas.hpp
@@ -3,8 +3,8 @@
 
 #include "LinElas_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "LinElas_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "LinElas_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/specific/LinElas_def.hpp
+++ b/feddlib/problems/specific/LinElas_def.hpp
@@ -1,6 +1,10 @@
 #ifndef LINELAS_def_hpp
 #define LINELAS_def_hpp
-#include "LinElas_decl.hpp"
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib/core/FE/FE.hpp"
+
+
 namespace FEDD {
 // Funktion fuer den homogenen Dirichletrand
 // void ZeroDirichlet(double* x, double* result, double t, double* parameters)

--- a/feddlib/problems/specific/NavierStokes.cpp
+++ b/feddlib/problems/specific/NavierStokes.cpp
@@ -1,6 +1,5 @@
-#include "NavierStokes_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "NavierStokes_decl.hpp"
 #include "NavierStokes_def.hpp"
 namespace FEDD{
     template class NavierStokes<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/specific/NavierStokes.hpp
+++ b/feddlib/problems/specific/NavierStokes.hpp
@@ -3,8 +3,8 @@
 
 #include "NavierStokes_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "NavierStokes_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "NavierStokes_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/specific/NavierStokesAssFE.cpp
+++ b/feddlib/problems/specific/NavierStokesAssFE.cpp
@@ -1,6 +1,5 @@
-#include "NavierStokesAssFE_decl.hpp"
-
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "NavierStokesAssFE_decl.hpp"
 #include "NavierStokesAssFE_def.hpp"
 namespace FEDD{
     template class NavierStokesAssFE<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/specific/NavierStokesAssFE.hpp
+++ b/feddlib/problems/specific/NavierStokesAssFE.hpp
@@ -3,8 +3,8 @@
 
 #include "NavierStokesAssFE_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "NavierStokes_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "NavierStokesAssFE_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/specific/NavierStokesAssFE_def.hpp
+++ b/feddlib/problems/specific/NavierStokesAssFE_def.hpp
@@ -1,6 +1,5 @@
 #ifndef NAVIERSTOKESASSFE_def_hpp
 #define NAVIERSTOKESASSFE_def_hpp
-#include "NavierStokesAssFE_decl.hpp"
 
 /*!
  Definition of Navier-Stokes
@@ -10,6 +9,12 @@
  @version 1.0
  @copyright CH
  */
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib//core/FE/FE.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+
 
 /*void sxOne2D(double* x, double* res, double t, double* parameter){
 

--- a/feddlib/problems/specific/NavierStokes_decl.hpp
+++ b/feddlib/problems/specific/NavierStokes_decl.hpp
@@ -1,9 +1,13 @@
 #ifndef NAVIERSTOKES_decl_hpp
 #define NAVIERSTOKES_decl_hpp
-#include "feddlib/problems/abstract/NonLinearProblem.hpp"
+
 #include <Thyra_ProductVectorBase.hpp>
 #include <Thyra_PreconditionerBase.hpp>
 #include <Thyra_ModelEvaluatorBase_decl.hpp>
+
+#include "feddlib/problems/abstract/NonLinearProblem.hpp"
+
+
 /*!
  Declaration of Navier-Stokes
 
@@ -14,7 +18,10 @@
  */
 
 namespace FEDD{
-
+template <class SC, class LO, class GO, class NO>
+class Matrix;
+template <class SC, class LO, class GO, class NO>
+class BCBuilder;
 
 template <class SC = default_sc, class LO = default_lo, class GO = default_go, class NO = default_no>
 class NavierStokes : public NonLinearProblem<SC,LO,GO,NO>  {

--- a/feddlib/problems/specific/NavierStokes_def.hpp
+++ b/feddlib/problems/specific/NavierStokes_def.hpp
@@ -1,6 +1,5 @@
 #ifndef NAVIERSTOKES_def_hpp
 #define NAVIERSTOKES_def_hpp
-#include "NavierStokes_decl.hpp"
 
 #ifndef NAVIER_STOKES_START
 #define NAVIER_STOKES_START(A,S) Teuchos::RCP<Teuchos::TimeMonitor> A = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(std::string("Assemble Navier-Stokes:") + std::string(S))));
@@ -9,6 +8,10 @@
 #ifndef NAVIER_STOKES_STOP
 #define NAVIER_STOKES_STOP(A) A.reset();
 #endif
+
+#include "feddlib/core/LinearAlgebra/Matrix.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
 
 /*!
  Definition of Navier-Stokes

--- a/feddlib/problems/specific/NonLinElasticity.cpp
+++ b/feddlib/problems/specific/NonLinElasticity.cpp
@@ -1,5 +1,5 @@
-#include "NonLinElasticity_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "NonLinElasticity_decl.hpp"
 #include "NonLinElasticity_def.hpp"
 namespace FEDD{
 template class NonLinElasticity<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/specific/NonLinElasticity.hpp
+++ b/feddlib/problems/specific/NonLinElasticity.hpp
@@ -2,8 +2,8 @@
 #define NonLinElasticity_hpp
 
 #include "NonLinElasticity_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "NonLinElasticity_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "NonLinElasticity_def.hpp"
+#endif
 
 #endif // NonLinElasticity_hpp

--- a/feddlib/problems/specific/NonLinElasticity_def.hpp
+++ b/feddlib/problems/specific/NonLinElasticity_def.hpp
@@ -1,6 +1,6 @@
 #ifndef NonLinElasticity_def_hpp
 #define NonLinElasticity_def_hpp
-#include "NonLinElasticity_decl.hpp"
+
 /*!
  Definition of NonLinElasticity
  
@@ -9,6 +9,10 @@
  @version 1.0
  @copyright CH
  */
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib//core/FE/FE.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 
 
 namespace FEDD {

--- a/feddlib/problems/specific/NonLinLaplace.cpp
+++ b/feddlib/problems/specific/NonLinLaplace.cpp
@@ -1,5 +1,5 @@
-#include "NonLinLaplace_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "NonLinLaplace_decl.hpp"
 #include "NonLinLaplace_def.hpp"
 namespace FEDD {
 template class NonLinLaplace<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/specific/NonLinLaplace.hpp
+++ b/feddlib/problems/specific/NonLinLaplace.hpp
@@ -2,8 +2,8 @@
 #define NonLinLaplace_hpp
 
 #include "NonLinLaplace_decl.hpp"
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "NonLinLaplace_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "NonLinLaplace_def.hpp"
+#endif
 
 #endif // NonLinLaplace_hpp

--- a/feddlib/problems/specific/NonLinLaplace_def.hpp
+++ b/feddlib/problems/specific/NonLinLaplace_def.hpp
@@ -1,6 +1,6 @@
 #ifndef NonLinLaplace_def_hpp
 #define NonLinLaplace_def_hpp
-#include "NonLinLaplace_decl.hpp"
+
 /*!
  Definition of NonLinLaplace
 
@@ -9,6 +9,11 @@
  @version 1.0
  @copyright KH
  */
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib//core/FE/FE.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+
 
 namespace FEDD {
 template <class SC, class LO, class GO, class NO>

--- a/feddlib/problems/specific/Stokes.cpp
+++ b/feddlib/problems/specific/Stokes.cpp
@@ -1,5 +1,5 @@
-#include "Stokes_decl.hpp"
 #ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "Stokes_decl.hpp"
 #include "Stokes_def.hpp"
 namespace FEDD {
     template class Stokes<default_sc, default_lo, default_go, default_no>;

--- a/feddlib/problems/specific/Stokes.hpp
+++ b/feddlib/problems/specific/Stokes.hpp
@@ -3,8 +3,8 @@
 
 #include "Stokes_decl.hpp"
 
-// #ifndef HAVE_EXPLICIT_INSTANTIATION
-// #include "Stokes_def.hpp"
-// #endif
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "Stokes_def.hpp"
+#endif
 
 #endif

--- a/feddlib/problems/specific/Stokes_def.hpp
+++ b/feddlib/problems/specific/Stokes_def.hpp
@@ -1,6 +1,6 @@
 #ifndef STOKES_def_hpp
 #define STOKES_def_hpp
-#include "Stokes_decl.hpp"
+
 /*!
  Definition of Stokes
  
@@ -9,6 +9,10 @@
  @version 1.0
  @copyright CH
  */
+
+#include "feddlib/core/FE/Domain.hpp"
+#include "feddlib//core/FE/FE.hpp"
+#include "feddlib/problems/Solver/Preconditioner.hpp"
 
 namespace FEDD {
 void ZeroDirichlet(double* x, double* res, double t, double* parameters){

--- a/feddlib/problems/tests/UnitTest/generalizedNewtonianPowerLawTest.cpp
+++ b/feddlib/problems/tests/UnitTest/generalizedNewtonianPowerLawTest.cpp
@@ -9,15 +9,13 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/General/HDF5Export.hpp"
 #include "feddlib/core/General/HDF5Import.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/problems/specific/NavierStokesAssFE.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
 

--- a/feddlib/problems/tests/UnitTest/laplaceUnitTest.cpp
+++ b/feddlib/problems/tests/UnitTest/laplaceUnitTest.cpp
@@ -1,16 +1,15 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
-
 #include "feddlib/problems/specific/Laplace.hpp"
 #include "feddlib/core/General/HDF5Import.hpp"
 #include "feddlib/core/General/HDF5Export.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+
 
 
 /*!

--- a/feddlib/problems/tests/UnitTest/linElasUnitTest.cpp
+++ b/feddlib/problems/tests/UnitTest/linElasUnitTest.cpp
@@ -1,16 +1,14 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/General/HDF5Export.hpp"
 #include "feddlib/core/General/HDF5Import.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
-
 #include "feddlib/problems/specific/LinElas.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 
 
 /*!

--- a/feddlib/problems/tests/UnitTest/navierStokesUnitTest.cpp
+++ b/feddlib/problems/tests/UnitTest/navierStokesUnitTest.cpp
@@ -1,8 +1,7 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/General/HDF5Export.hpp"

--- a/feddlib/problems/tests/UnitTest/navierStokesUnitTestPrec.cpp
+++ b/feddlib/problems/tests/UnitTest/navierStokesUnitTestPrec.cpp
@@ -1,8 +1,7 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/General/HDF5Export.hpp"

--- a/feddlib/problems/tests/UnitTest/nonLinElasticityUnitTest.cpp
+++ b/feddlib/problems/tests/UnitTest/nonLinElasticityUnitTest.cpp
@@ -6,6 +6,7 @@
 #include <Teuchos_XMLParameterListHelpers.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"

--- a/feddlib/problems/tests/UnitTest/nonLinLaplaceUnitTest.cpp
+++ b/feddlib/problems/tests/UnitTest/nonLinLaplaceUnitTest.cpp
@@ -1,8 +1,7 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"

--- a/feddlib/problems/tests/UnitTest/stokesUnitTest.cpp
+++ b/feddlib/problems/tests/UnitTest/stokesUnitTest.cpp
@@ -1,15 +1,13 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/General/HDF5Export.hpp"
 #include "feddlib/core/General/HDF5Import.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/problems/specific/Stokes.hpp"
 
 /*!

--- a/feddlib/problems/tests/steadyGeneralizedNewtonianAssFE/main.cpp
+++ b/feddlib/problems/tests/steadyGeneralizedNewtonianAssFE/main.cpp
@@ -9,7 +9,6 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/FE/Domain.hpp"
@@ -18,6 +17,7 @@
 
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
 #include "feddlib/problems/specific/NavierStokesAssFE.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 
 
 #include <boost/function.hpp>

--- a/feddlib/problems/tests/steadyLinElasAssFE/main.cpp
+++ b/feddlib/problems/tests/steadyLinElasAssFE/main.cpp
@@ -1,13 +1,15 @@
+#include <Teuchos_GlobalMPISession.hpp>
+#include <Tpetra_Core.hpp>
+
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/problems/specific/LinElas.hpp"
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Tpetra_Core.hpp>
+#include "feddlib/core/General/BCBuilder.hpp"
+
 
 void zeroDirichlet(double* x, double* res, double t, const double* parameters)
 {

--- a/feddlib/problems/tests/steadyNavierStokesAssFE/main.cpp
+++ b/feddlib/problems/tests/steadyNavierStokesAssFE/main.cpp
@@ -11,11 +11,11 @@
 #include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/FE/Domain.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
-
+#include "feddlib/core/General/BCBuilder.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
+#include "feddlib/problems/specific/NavierStokes.hpp"
 #include "feddlib/problems/specific/NavierStokesAssFE.hpp"
 
 

--- a/feddlib/problems/tests/steadyNonLinElasAssFE/main.cpp
+++ b/feddlib/problems/tests/steadyNonLinElasAssFE/main.cpp
@@ -1,8 +1,6 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
@@ -10,6 +8,8 @@
 #include "feddlib/problems/specific/LinElas.hpp"
 #include "feddlib/problems/specific/NonLinElasticity.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+
 
 void zeroDirichlet(double* x, double* res, double t, const double* parameters)
 {

--- a/feddlib/problems/tests/unsteadyLinElasAssFE/main.cpp
+++ b/feddlib/problems/tests/unsteadyLinElasAssFE/main.cpp
@@ -17,14 +17,14 @@
 #include <Tpetra_Core.hpp>
 
 #include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/problems/Solver/DAESolverInTime.hpp"
 #include "feddlib/problems/specific/LinElas.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
+
 
 void rhs2D(double* x, double* res, double* parameters){
     

--- a/feddlib/problems/tests/unsteadyNavierStokesAssFE/main.cpp
+++ b/feddlib/problems/tests/unsteadyNavierStokesAssFE/main.cpp
@@ -11,13 +11,13 @@
 #include "feddlib/core/FEDDCore.hpp"
 #include "feddlib/core/FE/Domain.hpp"
 #include "feddlib/core/Mesh/MeshPartitioner.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
 #include "feddlib/core/General/ExporterParaView.hpp"
 #include "feddlib/core/LinearAlgebra/MultiVector.hpp"
 #include "feddlib/problems/Solver/DAESolverInTime.hpp"
 #include "feddlib/problems/Solver/NonLinearSolver.hpp"
 #include "feddlib/problems/specific/NavierStokes.hpp"
 #include "feddlib/problems/specific/NavierStokesAssFE.hpp"
+#include "feddlib/core/General/BCBuilder.hpp"
 
 /*!
  main of time-dependent Navier-Stokes problem


### PR DESCRIPTION
* Consistent use of angle brackets and double quotes
* Remove self inclusion of header files
* Remove circular dependency
* Revise other dependency inclusions
* Address explicit instantiation

This PR does not completely revise the inclusion of headers. Since the other PR #73 got too big and cumbersome to maintain, I moved its current state here, which is ready to be merged. Some things will have to be cleaned up again: Due to divergent branches, the inclusion of unnecessary Xpetra header files probably made it back into the codebase. The discussion will continue in PR #73.