### PR TITLE
Include in NavierStokesAssFE Pressure Projection and Allow FixedPoint/Newton to Recycle Monolithic Preconditioner like in NOX

### DIFF
--- a/feddlib/problems/Solver/NonLinearSolver_def.hpp
+++ b/feddlib/problems/Solver/NonLinearSolver_def.hpp
@@ -323,7 +323,8 @@ void NonLinearSolver<SC,LO,GO,NO>::solveFixedPoint(NonLinearProblem_Type &proble
                 break;
         }
 
-
+        // Set the current Nonlinear Step in the Problem class
+        problem.setNonlinearIterationStep(nlIts);
         gmresIts += problem.solveAndUpdate( criterion, criterionValue );
         nlIts++;
         if(criterion=="Update"){
@@ -385,6 +386,8 @@ void NonLinearSolver<SC,LO,GO,NO>::solveNewton( NonLinearProblem_Type &problem, 
                 break;
         }
         // PRINT INFOS
+        // Set the current Nonlinear Step in the Problem class
+        problem.setNonlinearIterationStep(nlIts);
         gmresIts += problem.solveAndUpdate( criterion, criterionValue );
         nlIts++;
         if(criterion=="Update"){
@@ -481,6 +484,8 @@ void NonLinearSolver<SC,LO,GO,NO>::solveFixedPointNewton( NonLinearProblem_Type 
 
 
         // PRINT INFOS
+        // Set the current Nonlinear Step in the Problem class
+        problem.setNonlinearIterationStep(nlIts);
         gmresIts += problem.solveAndUpdate( criterion, criterionValue );
         nlIts++;
         if(criterion=="Update"){

--- a/feddlib/problems/abstract/NonLinearProblem_decl.hpp
+++ b/feddlib/problems/abstract/NonLinearProblem_decl.hpp
@@ -154,6 +154,11 @@ public:
     void initVectorSpacesBlock( );
 
     virtual ::Thyra::ModelEvaluatorBase::OutArgs<SC> createOutArgsImpl() const;
+
+    
+    void setNonlinearIterationStep(int newtonStep)  { this->newtonStep_ = newtonStep;}   // For SolveFixedPoint etc. we need to set the Newton Step manually
+    int  getNonlinearIterationStep() const override { return newtonStep_; }              // This overrides the default in Problem to provide the actual Newton step
+
     
     double nonLinearTolerance_;
     BlockMultiVectorPtr_Type    previousSolution_;

--- a/feddlib/problems/abstract/Problem_decl.hpp
+++ b/feddlib/problems/abstract/Problem_decl.hpp
@@ -104,6 +104,11 @@ public:
 
     virtual void info() = 0;
 
+    /*! If we have a Nonlinear Problem, we need the opportunity to know about the current Newton Step -> override in NonLinearProblem
+        Default implementation just returns 0
+    */
+    virtual int getNonlinearIterationStep() const{return 0; } 
+
     void infoProblem();
 
     void infoParameter(bool full = true, std::string ="empty");


### PR DESCRIPTION
Main Changes:
- Added in NavierStokesAssFE the Code to add pressure projection if in parametersProblem file is accordingly set
- Lea also implented for NOX that the whole monolithic preconditioner can be rebuilt after x nonlinear iteration step, I just added this for FixedPoint and Newton, therefore I had to be able to asses the current nonlinear iteration step in LinearSolver_def.hpp 