### PR TITLE
Split FE class into two

### DIFF
--- a/feddlib/core/FE/CMakeLists.txt
+++ b/feddlib/core/FE/CMakeLists.txt
@@ -8,6 +8,9 @@ set(FE_HEADERS
 	FE/FE.hpp
 	FE/FE_decl.hpp
 	FE/FE_def.hpp
+	FE/FE_ElementAssembly.hpp
+	FE/FE_ElementAssembly_decl.hpp
+	FE/FE_ElementAssembly_def.hpp
 	FE/FiniteElement.hpp
 	FE/TriangleElements.hpp
     FE/sms.hpp
@@ -20,6 +23,7 @@ set(FE_SOURCES
     FE/Elements.cpp
     FE/EntitiesOfElements.cpp
 	FE/FE.cpp
+    FE/FE_ElementAssembly.cpp
     FE/FiniteElement.cpp  
 	FE/TriangleElements.cpp  
     FE/SMSUtility.cpp

--- a/feddlib/core/FE/FE_ElementAssembly.cpp
+++ b/feddlib/core/FE/FE_ElementAssembly.cpp
@@ -1,0 +1,8 @@
+#ifdef HAVE_EXPLICIT_INSTANTIATION
+#include "FE_ElementAssembly_decl.hpp"
+#include "FE_ElementAssembly_def.hpp"
+namespace FEDD {
+    template class FE_ElementAssembly<default_sc, default_lo, default_go, default_no>;
+}
+#endif  // HAVE_EXPLICIT_INSTANTIATION
+

--- a/feddlib/core/FE/FE_ElementAssembly.hpp
+++ b/feddlib/core/FE/FE_ElementAssembly.hpp
@@ -1,0 +1,8 @@
+#ifndef FE_ElementAssembly_hpp
+#define FE_ElementAssembly_hpp
+#include "FE_ElementAssembly_decl.hpp"
+#ifndef HAVE_EXPLICIT_INSTANTIATION
+    #include "FE_ElementAssembly_def.hpp"
+#endif
+
+#endif // MATRIX_hpp

--- a/feddlib/core/FE/FE_ElementAssembly_decl.hpp
+++ b/feddlib/core/FE/FE_ElementAssembly_decl.hpp
@@ -1,0 +1,287 @@
+#ifndef FE_ELEMENTASSEMBLY_DECL_hpp
+#define FE_ELEMENTASSEMBLY_DECL_hpp
+
+
+#include "feddlib/core/FEDDCore.hpp"
+#include "feddlib/core/General/SmallMatrix.hpp"
+#include "feddlib/core/General/DefaultTypeDefs.hpp"
+#include "feddlib/core/LinearAlgebra/Matrix.hpp"
+#include "feddlib/core/LinearAlgebra/MultiVector.hpp"
+#include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
+#include "Domain.hpp"
+#include "Helper.hpp"
+#include "sms.hpp"
+#include "feddlib/core/AceFemAssembly/AssembleFE.hpp"
+#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation.hpp"
+#include "feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes.hpp"
+
+#include "feddlib/core/AceFemAssembly/AssembleFEFactory.hpp"
+
+#include <Teuchos_Array.hpp>
+#include <Teuchos_BLAS.hpp>
+
+
+/*!
+ Declaration of FE
+
+ @brief  FE
+ @author Christian Hochmuth
+ @version 1.0
+ @copyright CH
+ */
+
+namespace FEDD {
+
+
+template <class SC = default_sc, class LO = default_lo, class GO = default_go, class NO = default_no>
+class FE_ElementAssembly {
+  public:
+
+    typedef Domain<SC,LO,GO,NO> Domain_Type;
+    typedef Teuchos::RCP<Domain_Type> DomainPtr_Type;
+    typedef Teuchos::RCP<const Domain_Type> DomainConstPtr_Type;
+    typedef std::vector<DomainConstPtr_Type> DomainConstPtr_vec_Type;
+
+    typedef Teuchos::RCP<Mesh<SC,LO,GO,NO> > MeshPtr_Type;
+    typedef MeshUnstructured<SC,LO,GO,NO> MeshUnstr_Type;
+    typedef Teuchos::RCP<MeshUnstr_Type> MeshUnstrPtr_Type;
+    
+    typedef Elements Elements_Type;
+    typedef Teuchos::RCP<Elements_Type> ElementsPtr_Type;
+    typedef Teuchos::RCP<const Elements_Type> ElementsConstPtr_Type;
+    
+    typedef Matrix<SC,LO,GO,NO> Matrix_Type;
+    typedef Teuchos::RCP<Matrix_Type> MatrixPtr_Type;
+
+    typedef typename Matrix_Type::MapPtr_Type MapPtr_Type;
+    typedef typename Matrix_Type::MapConstPtr_Type MapConstPtr_Type;
+
+    typedef MultiVector<SC,LO,GO,NO> MultiVector_Type;
+    typedef Teuchos::RCP<MultiVector_Type> MultiVectorPtr_Type;
+    typedef Teuchos::RCP<const MultiVector_Type> MultiVectorConstPtr_Type;
+
+    typedef std::vector<GO> vec_GO_Type;
+    typedef std::vector<vec_GO_Type> vec2D_GO_Type;
+    typedef std::vector<vec2D_GO_Type> vec3D_GO_Type;
+    typedef Teuchos::RCP<vec3D_GO_Type> vec3D_GO_ptr_Type;
+    
+	typedef AssembleFE<SC,LO,GO,NO> AssembleFE_Type;
+    typedef Teuchos::RCP<AssembleFE_Type> AssembleFEPtr_Type;
+
+	typedef AssembleFENavierStokes<SC,LO,GO,NO> AssembleFENavierStokes_Type;
+    typedef Teuchos::RCP<AssembleFENavierStokes_Type> AssembleFENavierStokesPtr_Type;
+
+    typedef AssembleFEGeneralizedNewtonian<SC,LO,GO,NO> AssembleFEGeneralizedNewtonian_Type;
+    typedef Teuchos::RCP<AssembleFEGeneralizedNewtonian_Type> AssembleFEGeneralizedNewtonianPtr_Type;
+
+    typedef AssembleFE_SCI_SMC_Active_Growth_Reorientation<SC,LO,GO,NO> AssembleFE_SCI_SMC_Active_Growth_Reorientation_Type;
+    typedef Teuchos::RCP<AssembleFE_SCI_SMC_Active_Growth_Reorientation_Type> AssembleFE_SCI_SMC_Active_Growth_Reorientation_Ptr_Type;
+
+    typedef std::vector<AssembleFEPtr_Type> AssembleFEPtr_vec_Type;	
+
+    typedef BlockMatrix<SC,LO,GO,NO> BlockMatrix_Type ;
+    typedef Teuchos::RCP<BlockMatrix_Type> BlockMatrixPtr_Type;
+
+    typedef BlockMultiVector<SC,LO,GO,NO> BlockMultiVector_Type ;
+    typedef Teuchos::RCP<BlockMultiVector_Type> BlockMultiVectorPtr_Type;
+
+	typedef SmallMatrix<SC> SmallMatrix_Type;
+    typedef Teuchos::RCP<SmallMatrix_Type> SmallMatrixPtr_Type;
+
+    /* ###################################################################### */
+
+    FE_ElementAssembly(bool saveAssembly=false);
+    
+    void addFE(DomainConstPtr_Type domain);
+
+    void doSetZeros(double eps = 10*Teuchos::ScalarTraits<SC>::eps());
+
+    void assemblyEmptyMatrix(MatrixPtr_Type &A);
+
+    void assemblyNonlinearLaplace(
+        int dim, std::string FEType, int degree, MultiVectorPtr_Type u_rep,
+        BlockMatrixPtr_Type &A, BlockMultiVectorPtr_Type &resVec,
+        ParameterListPtr_Type params, std::string assembleMode,
+        bool callFillComplete = true, int FELocExternal = -1);
+
+
+    void assemblyNavierStokes(int dim,
+								std::string FETypeVelocity,
+								std::string FETypePressure,
+								int degree,
+								int dofsVelocity,
+								int dofsPressure,
+								MultiVectorPtr_Type u_rep,
+								MultiVectorPtr_Type p_rep,
+								BlockMatrixPtr_Type &A,
+								BlockMultiVectorPtr_Type &resVec,
+								SmallMatrix_Type coeff,
+								ParameterListPtr_Type params,
+								bool reAssemble,
+							        std::string assembleMode,
+								bool callFillComplete = true,
+								int FELocExternal=-1);
+
+    void assemblyLaplaceAssFE(int dim,
+                            std::string FEType,
+                            int degree,
+                            int dofs,
+                            BlockMatrixPtr_Type &A,
+                            bool callFillComplete,
+                            int FELocExternal=-1);
+
+    void assemblyAceDeformDiffu(int dim,
+								std::string FETypeChem,
+								std::string FETypeSolid,
+								int degree,
+								int dofsChem,
+								int dofsSolid,
+								MultiVectorPtr_Type c_rep,
+								MultiVectorPtr_Type d_rep,
+								BlockMatrixPtr_Type &A,
+								BlockMultiVectorPtr_Type &resVec,
+								ParameterListPtr_Type params,
+							        std::string assembleMode,
+								bool callFillComplete = true,
+								int FELocExternal=-1);
+
+    void assemblyAceDeformDiffuBlock(int dim,
+                                std::string FETypeChem,
+                                std::string FETypeSolid,
+                                int degree,
+                                int dofsChem,
+                                int dofsSolid,
+                                MultiVectorPtr_Type c_rep,
+                                MultiVectorPtr_Type d_rep,
+                                BlockMatrixPtr_Type &A,
+                                int blockRow,
+                                int blockCol,
+                                BlockMultiVectorPtr_Type &resVec,
+                                int block,
+                                ParameterListPtr_Type params,
+                                std::string assembleMode,
+                                bool callFillComplete = true,
+                                int FELocExternal=-1);
+
+    void advanceInTimeAssemblyFEElements(double dt ,MultiVectorPtr_Type d_rep , MultiVectorPtr_Type c_rep) 
+    {
+        //UN FElocChem = 1; //checkFE(dim,FETypeChem); // Checks for different domains which belongs to a certain fetype
+        UN FElocSolid = 0; //checkFE(dim,FETypeSolid); // Checks for different domains which belongs to a certain fetype
+
+        //ElementsPtr_Type elementsChem= domainVec_.at(FElocChem)->getElementsC();
+
+        ElementsPtr_Type elementsSolid = domainVec_.at(FElocSolid)->getElementsC();
+        
+        vec_dbl_Type solution_c;
+	    vec_dbl_Type solution_d;
+        for (UN T=0; T<assemblyFEElements_.size(); T++) {
+		    vec_dbl_Type solution(0);
+
+            solution_c = getSolution(elementsSolid->getElement(T).getVectorNodeList(), c_rep,1);
+            solution_d = getSolution(elementsSolid->getElement(T).getVectorNodeList(), d_rep,3);
+            // First Solid, then Chemistry
+            solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
+            solution.insert( solution.end(), solution_c.begin(), solution_c.end() );
+            
+            assemblyFEElements_[T]->updateSolution(solution);
+
+            assemblyFEElements_[T]->advanceInTime(dt);
+        }
+        
+    }
+
+	void assemblyLinearElasticity(int dim,
+                                std::string FEType,
+                                int degree,
+                                int dofs,
+                                MultiVectorPtr_Type d_rep,
+                                BlockMatrixPtr_Type &A,
+                                BlockMultiVectorPtr_Type &resVec,
+                                ParameterListPtr_Type params,
+                                bool reAssemble,
+                                std::string assembleMode,
+                                bool callFillComplete=true,
+                                int FELocExternal=-1);
+
+    void assemblyNonLinearElasticity(int dim,
+                                    std::string FEType,
+                                    int degree,
+                                    int dofs,
+                                    MultiVectorPtr_Type d_rep,
+                                    BlockMatrixPtr_Type &A,
+                                    BlockMultiVectorPtr_Type &resVec,
+                                    ParameterListPtr_Type params,
+                                    bool callFillComplete=true,
+                                    int FELocExternal=-1);
+                                    
+    void assemblyNonLinearElasticity(int dim,
+                                    std::string FEType,
+                                    int degree,
+                                    int dofs,
+                                    MultiVectorPtr_Type d_rep,
+                                    BlockMatrixPtr_Type &A,
+                                    BlockMultiVectorPtr_Type &resVec,
+                                    ParameterListPtr_Type params, 									
+                                    DomainConstPtr_Type domain,
+                                    MultiVectorPtr_Type eModVec,
+                                    bool callFillComplete = true,
+                                    int FELocExternal=-1);
+                                    
+
+    /* Given a converged velocity solution this function 
+       computes the averaged viscosity estimate in each cell at the center of mass 
+       - CM stands for center of mass so the values at the node are averaged to obtain one value
+    */
+    void computeSteadyViscosityFE_CM(int dim,
+	                                    std::string FETypeVelocity,
+	                                    std::string FETypePressure,
+										int dofsVelocity,
+										int dofsPressure,
+										MultiVectorPtr_Type u_rep,
+										MultiVectorPtr_Type p_rep,
+ 										ParameterListPtr_Type params);
+
+    // Change for all assembleFEElements the linearization type to the specified ones
+    void  changeLinearizationFE(std::string linearization);
+
+    // Write prostprocessing output fields like e.g. the viscosity based on  velocity, pressure .. solution
+    // inside this BMV -> For visualization or postprocessing                                
+    BlockMultiVectorPtr_Type const_output_fields;
+
+    DomainConstPtr_vec_Type	domainVec_;
+
+
+/* ----------------------------------------------------------------------------------------*/
+protected:
+    // Protected attributes/ functions such that derived FE classes can access them
+    bool setZeros_;
+    SC myeps_;
+    bool saveAssembly_;
+
+    int checkFE(int Dimension,
+                std::string FEType);
+
+    vec2D_dbl_Type getCoordinates(vec_LO_Type localIDs, vec2D_dbl_ptr_Type points);
+	vec_dbl_Type getSolution(vec_LO_Type localIDs, MultiVectorPtr_Type u_rep, int dofsVelocity);
+
+
+/* ----------------------------------------------------------------------------------------*/
+private:
+    // Functions to add element contributions to global system matrices/ vectors
+	void addFeBlockMatrix(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement element1,FiniteElement element2, MapConstPtr_Type mapFirstColumn,MapConstPtr_Type mapSecondColumn, tuple_disk_vec_ptr_Type problemDisk);
+
+	void addFeBlock(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement element, MapConstPtr_Type mapFirstRow, int row, int column, tuple_disk_vec_ptr_Type problemDisk);
+
+    void initAssembleFEElements(std::string elementType, tuple_disk_vec_ptr_Type problemDisk, ElementsPtr_Type elements, ParameterListPtr_Type params, vec2D_dbl_ptr_Type pointsRep, MapConstPtr_Type elementMap);
+
+    void addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec, FiniteElement elementBlock1,FiniteElement elementBlock2, int dofs1, int dofs2 );
+
+    void addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec, FiniteElement elementBlock, int dofs);
+
+
+	AssembleFEPtr_vec_Type assemblyFEElements_;
+
+
+};
+}
+#endif

--- a/feddlib/core/FE/FE_ElementAssembly_def.hpp
+++ b/feddlib/core/FE/FE_ElementAssembly_def.hpp
@@ -1,0 +1,1632 @@
+#ifndef FE_ELEMENTASSEMBLY_DEF_hpp
+#define FE_ELEMENTASSEMBLY_DEF_hpp
+
+#include <string>
+#include "feddlib/core/core_config.h"
+#ifdef FEDD_HAVE_ACEGENINTERFACE
+#include <aceinterface.hpp>
+#endif
+
+/*!
+ Definition of FE_ElementAssembly
+
+ @brief  FE_ElementAssembly
+ @author Christian Hochmuth
+ @version 1.0
+ @copyright CH
+ */
+
+
+
+using Teuchos::reduceAll;
+using Teuchos::REDUCE_SUM;
+using Teuchos::outArg;
+
+namespace FEDD {
+
+
+template <class SC, class LO, class GO, class NO>
+FE_ElementAssembly<SC,LO,GO,NO>::FE_ElementAssembly(bool saveAssembly):
+domainVec_(0),
+setZeros_(false),
+myeps_(),
+saveAssembly_(saveAssembly)
+{
+}
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::addFE(DomainConstPtr_Type domain){
+    
+    if (saveAssembly_){
+        DomainPtr_Type domainNC = Teuchos::rcp_const_cast<Domain_Type>( domain );
+        domainNC->initializeFEData();
+    }
+    domainVec_.push_back(domain);
+
+}
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::doSetZeros(double eps){
+
+    setZeros_ = true;
+    myeps_ = eps;
+
+}
+
+/*!
+
+ \brief Assembly of Jacobian 
+@param[in] dim Dimension
+@param[in] FEType FE Discretization
+@param[in] degree Degree of basis function
+@param[in] A Resulting matrix
+@param[in] callFillComplete If Matrix A should be completely filled at end of function
+@param[in] FELocExternal 
+
+*/
+
+// Check the order of chemistry and solid in system matrix
+/*template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::globalAssembly(std::string ProblemType,
+                        int dim,                    
+                        int degree,                       
+                        MultiVectorPtr_Type sol_rep,
+                        BlockMatrixPtr_Type &A,
+                        BlockMultiVectorPtr_Type &resVec,
+                        ParameterListPtr_Type params,
+                        std::string assembleMode,
+                        bool callFillComplete,
+                        int FELocExternal){
+
+    int problemSize = domainVec_.size(); // Problem size, as in number of subproblems
+
+    // Depending on problem size we extract necessary information 
+
+	/// Tupel construction follows follwing pattern:
+	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
+	int numChem=3;
+    if(FETypeChem == "P2"){
+        numChem=6;
+    }    
+	if(dim==3){
+		numChem=4;
+        if(FETypeChem == "P2")
+            numChem=10;
+	}
+    int numSolid=3;
+    if(FETypeSolid == "P2")
+        numSolid=6;
+        
+	if(dim==3){
+		numSolid=4;
+        if(FETypeSolid == "P2")
+            numSolid=10;
+	}
+
+	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 2) );
+
+	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
+    for(int i=0; i< problemSize; i++){
+        int numNodes=0.;
+        if(domainVec.at(i)->getFEType() == "P2"){
+            numNodes=6;
+        }    
+        if(dim==3){
+            numNodes=4;
+            if(domainVec.at(i)->getFEType() == "P2")
+                numNodes=10;
+        }
+        tuple_ssii_Type infoTuple (domainVec.at(i)->getPhysic(),domainVec.at(i)->getFEType(),domainVec.at(i)->getDofs(),numChem);
+        problemDisk->push_back(infoTuple);
+
+        MultiVectorPtr_Type resVec;
+        if(domainVec.at(i)->getDofs() == 1)
+            resVec = Teuchos::rcp( new MultiVector_Type( domainVec_.at(i)->getMapRepeated(), 1 ) );
+        else
+            resVec = Teuchos::rcp( new MultiVector_Type( domainVec_.at(i)->getMapVecFieldRepeated(), 1 ) );
+
+        resVecRep->addBlock(resVec,i);
+
+
+    }
+	
+
+	if(assemblyFEElements_.size()== 0){
+       	initAssembleFEElements(ProblemType,problemDisk,domainVec_.at(0)->getElementsC(), params,domainVec_.at(0)->getPointsRepeated(),domainVec_.at(0)->getElementMap());
+    }
+	else if(assemblyFEElements_.size() != domainVec_.at(0)->getElementsC()->numberElements())
+	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
+
+    vec_dbl_Type solution_tmp;
+    for (UN T=0; T<assemblyFEElements_.size(); T++) {
+		vec_dbl_Type solution(0);
+        vec_FE_Type elements;
+        for(int i=0; i< problemSize; i++){
+		    solution_tmp = getSolution(domainVec_.at(i)->getElementsC()->getElement(T).getVectorNodeList(), sol_rep->getBlock(i),domainVec.at(i)->getDofs());      
+            solution.insert( solution.end(), solution_tmp.begin(), solution_tmp.end() );
+
+
+        }   
+        
+  		assemblyFEElements_[T]->updateSolution(solution);
+
+ 		SmallMatrixPtr_Type elementMatrix;
+	    vec_dbl_ptr_Type rhsVec;
+
+     	if(assembleMode == "Jacobian"){
+			assemblyFEElements_[T]->assembleJacobian();
+
+            elementMatrix = assemblyFEElements_[T]->getJacobian(); 
+            //elementMatrix->print();
+			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
+			
+			addFeBlockMatrix(A, elementMatrix, domainVec_.at(0)->getElementsC()->getElement(T), problemDisk);
+    
+		}
+		if(assembleMode == "Rhs"){
+		    assemblyFEElements_[T]->assembleRHS();
+		    rhsVec = assemblyFEElements_[T]->getRHS(); 
+			addFeBlockMv(resVecRep, rhsVec, elementsSolid->getElement(T),elementsChem->getElement(T), dofsSolid,dofsChem);
+
+		}
+      		
+	}
+	if ( assembleMode == "Jacobian"){
+        for(int probRow = 0; probRow <  problemSize; probRow++){
+            for(int probCol = 0; probCol <  problemSize; probCol++){
+                MapConstPtr_Type rowMap;
+                MapConstPtr_Type domainMap;
+
+                if(domainVec.at(probRow)->getDofs() == 1)
+                    rowMap = domainVec_.at(FElocRow)->getMapUnique();
+                else
+                    rowMap = domainVec_.at(probRow)->getMapVecFieldUnique();
+
+                if(domainVec.at(probCol)->getDofs() == 1)
+                    domainMap = domainVec_.at(probCol)->getMapUnique()
+                else
+                    domainMap = domainVec_.at(probCol)->getMapVecFieldUnique()
+
+                A->getBlock(probRow,probCol)->fillComplete(domainMap,rowMap);
+            }
+        }
+	}
+    else if(assembleMode == "Rhs"){
+
+        for(int probRow = 0; probRow <  problemSize; probRow++){
+            MapConstPtr_Type rowMap;
+             if(domainVec.at(probRow)->getDofs() == 1)
+                rowMap = domainVec_.at(FElocRow)->getMapUnique();
+            else
+                rowMap = domainVec_.at(probRow)->getMapVecFieldUnique();
+
+		    MultiVectorPtr_Type resVecUnique = Teuchos::rcp( new MultiVector_Type( rowMap, 1 ) );
+
+            resVecUnique->putScalar(0.);
+
+            resVecUnique->exportFromVector( resVecRep, true, "Add" );
+
+            resVec->addBlock(resVecUnique,probRow);
+        }
+	}
+
+}*/
+
+/*!
+
+ \brief Inserting element stiffness matrices into global stiffness matrix
+
+
+@param[in] &A Global Block Matrix
+@param[in] elementMatrix Stiffness matrix of one element
+@param[in] element Corresponding finite element
+@param[in] map Map that corresponds to repeated nodes of first block
+@param[in] map Map that corresponds to repeated nodes of second block
+
+*/
+/*template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::addFeBlockMatrix(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement_vec element, tuple_disk_vec_ptr_Type problemDisk){
+		
+    int numDisk = problemDisk->size();
+
+    for(int probRow = 0; probRow < numDisk; probRow++){
+        for(int probCol = 0; probCol < numDisk; probCol++){
+            int dofs1 = std::get<2>(problemDisk->at(probRow));
+            int dofs2 = std::get<2>(problemDisk->at(probCol));
+
+            int numNodes1 = std::get<3>(problemDisk->at(probRow));
+            int numNodes2=std::get<3>(problemDisk->at(probCol));
+
+            int offsetRow= numNodes1*dofs1*probRow;
+            int offsetCol= numNodes1*dofs1*probCol;
+
+            mapRow = domainVec.at(probRow)->getMapRepeated();
+            mapCol = domainVec.at(probCol)->getMapRepeated();
+
+            Teuchos::Array<SC> value2( numNodes2, 0. );
+            Teuchos::Array<GO> columnIndices2( numNodes2, 0 );
+            for (UN i=0; i < numNodes1; i++){
+                for(int di=0; di<dofs1; di++){				
+                    GO row =GO (dofs1* mapRow->getGlobalElement( element[probRow].getNode(i) )+di);
+                    for(int d=0; d<dofs2; d++){				
+                        for (UN j=0; j < numNodes2 ; j++) {
+                            value2[j] = (*elementMatrix)[offsetRow+i*dofs1+di][offsetCol+j*dofs2+d];			    				    		
+                            columnIndices2[j] =GO (dofs2* mapCol->getGlobalElement( element.getNode(j) )+d);
+                        }
+                        A->getBlock(probRow,probCol)->insertGlobalValues( row, columnIndices2(), value2() ); // Automatically adds entries if a value already exists                            
+                    }
+                }      
+            }
+
+        }
+    }
+}
+
+*/
+
+/*!
+
+ \brief Inserting local rhsVec into global residual Mv;
+
+
+@param[in] res BlockMultiVector of residual vec; Repeated distribution; 2 blocks
+@param[in] rhsVec sorted the same way as residual vec
+@param[in] element of block1
+
+*/
+/*
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec,tuple_disk_vec_ptr_Type problemDisk, FiniteElement_vec element)
+    int numDisk = problemDisk->size();
+
+    for(int probRow = 0; probRow < numDisk; probRow++){
+        Teuchos::ArrayRCP<SC>  resArray_block = res->getBlockNonConst(probRow)->getDataNonConst(0);
+      	vec_LO_Type nodeList_block = element[probRow].getVectorNodeList();
+        int dofs = std::get<2>(problemDisk->at(probRow));
+        int numNodes = std::get<3>(problemDisk->at(probRow));
+
+        int offset = numNodes*dofs; 
+        for(int i=0; i< nodeList_block.size() ; i++){
+            for(int d=0; d<dofs; d++){
+                resArray_block[nodeList_block[i]*dofs+d] += (*rhsVec)[i*dofs+d+offset];
+            }
+        }
+    }
+}
+*/
+
+/*!
+
+ \brief Assembly of Jacobian for Linear Elasticity
+@param[in] dim Dimension
+@param[in] FEType FE Discretization
+@param[in] degree Degree of basis function
+@param[in] A Resulting matrix
+@param[in] callFillComplete If Matrix A should be completely filled at end of function
+@param[in] FELocExternal 
+
+*/
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyLinearElasticity(int dim,
+	                                    std::string FEType,
+	                                    int degree,
+										int dofs,
+										MultiVectorPtr_Type d_rep,
+	                                    BlockMatrixPtr_Type &A,
+										BlockMultiVectorPtr_Type &resVec,
+ 										ParameterListPtr_Type params,
+ 										bool reAssemble,
+ 										std::string assembleMode,
+	                                    bool callFillComplete,
+	                                    int FELocExternal){
+	
+	ElementsPtr_Type elements = domainVec_.at(0)->getElementsC();
+
+	int dofsElement = elements->getElement(0).getVectorNodeList().size();
+
+	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(0)->getPointsRepeated();
+
+	MapConstPtr_Type mapVel = domainVec_.at(0)->getMapRepeated();
+
+	vec_dbl_Type solution(0);
+	vec_dbl_Type solution_d;
+
+	vec_dbl_Type rhsVec;
+
+	/// Tupel construction follows follwing pattern:
+	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
+	int numNodes=6;
+	if(dim==3){
+		numNodes=10;
+	}
+	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
+	tuple_ssii_Type displacement ("Displacement",FEType,dofs,numNodes);
+	problemDisk->push_back(displacement);
+
+	if(assemblyFEElements_.size()== 0)
+	 	initAssembleFEElements("LinearElasticity",problemDisk,elements, params,pointsRep,domainVec_.at(0)->getElementMap());
+	else if(assemblyFEElements_.size() != elements->numberElements())
+	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
+
+	MultiVectorPtr_Type resVec_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(0)->getMapVecFieldRepeated(), 1 ) );
+	
+	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 1) );
+	resVecRep->addBlock(resVec_d,0);
+
+ 	SmallMatrixPtr_Type elementMatrix;
+	for (UN T=0; T<assemblyFEElements_.size(); T++) {
+		vec_dbl_Type solution(0);
+
+		solution_d = getSolution(elements->getElement(T).getVectorNodeList(), d_rep,dofs);
+
+		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
+
+		assemblyFEElements_[T]->updateSolution(solution);
+ 
+		assemblyFEElements_[T]->assembleJacobian();
+
+		elementMatrix = assemblyFEElements_[T]->getJacobian(); 
+			
+		assemblyFEElements_[T]->advanceNewtonStep();
+
+
+		addFeBlock(A, elementMatrix, elements->getElement(T), mapVel, 0, 0, problemDisk);
+			
+	}
+	if (callFillComplete)
+	    A->getBlock(0,0)->fillComplete( domainVec_.at(0)->getMapVecFieldUnique(),domainVec_.at(0)->getMapVecFieldUnique());
+	
+
+
+
+}
+
+/*!
+
+ \brief Assembly of Jacobian for nonlinear Elasticity
+@param[in] dim Dimension
+@param[in] FEType FE Discretization
+@param[in] degree Degree of basis function
+@param[in] A Resulting matrix
+@param[in] callFillComplete If Matrix A should be completely filled at end of function
+@param[in] FELocExternal 
+
+*/
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyNonLinearElasticity(int dim,
+	                                    std::string FEType,
+	                                    int degree,
+										int dofs,
+										MultiVectorPtr_Type d_rep,
+	                                    BlockMatrixPtr_Type &A,
+										BlockMultiVectorPtr_Type &resVec,
+ 										ParameterListPtr_Type params, 									
+	                                    bool callFillComplete,
+	                                    int FELocExternal){
+	
+	ElementsPtr_Type elements = domainVec_.at(0)->getElementsC();
+
+	int dofsElement = elements->getElement(0).getVectorNodeList().size();
+
+	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(0)->getPointsRepeated();
+
+	MapConstPtr_Type map = domainVec_.at(0)->getMapRepeated();
+
+	vec_dbl_Type solution(0);
+	vec_dbl_Type solution_d;
+
+	vec_dbl_ptr_Type rhsVec;
+
+	/// Tupel construction follows follwing pattern:
+	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
+	int numNodes=6;
+	if(dim==3){
+		numNodes=10;
+	}
+	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
+	tuple_ssii_Type displacement ("Displacement",FEType,dofs,numNodes);
+	problemDisk->push_back(displacement);
+
+    int neoHookeNum = params->sublist("Parameter").get("Neo-Hooke Modell",1);
+
+    std::string nonLinElasModell = "NonLinearElasticity2";
+    if(neoHookeNum == 1)
+        nonLinElasModell = "NonLinearElasticity";
+
+    //std::cout << " ######## Assembly Modell: " << nonLinElasModell << " ############ " <<  std::endl;
+
+
+	if(assemblyFEElements_.size()== 0)
+	 	initAssembleFEElements(nonLinElasModell,problemDisk,elements, params,pointsRep,domainVec_.at(0)->getElementMap());
+	else if(assemblyFEElements_.size() != elements->numberElements())
+	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
+	
+
+ 	SmallMatrixPtr_Type elementMatrix;
+	for (UN T=0; T<assemblyFEElements_.size(); T++) {
+		vec_dbl_Type solution(0);
+
+		solution_d = getSolution(elements->getElement(T).getVectorNodeList(), d_rep,dofs);
+
+		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
+
+		assemblyFEElements_[T]->updateSolution(solution);
+
+        assemblyFEElements_[T]->assembleJacobian();
+        elementMatrix = assemblyFEElements_[T]->getJacobian();              
+        addFeBlock(A, elementMatrix, elements->getElement(T), map, 0, 0, problemDisk);
+
+        assemblyFEElements_[T]->assembleRHS();
+        rhsVec = assemblyFEElements_[T]->getRHS(); 
+        addFeBlockMv(resVec, rhsVec, elements->getElement(T),  dofs);
+
+        assemblyFEElements_[T]->advanceNewtonStep();
+
+
+	}
+	if (callFillComplete)
+	    A->getBlock(0,0)->fillComplete( domainVec_.at(0)->getMapVecFieldUnique(),domainVec_.at(0)->getMapVecFieldUnique());
+	
+}
+
+/*!
+
+ \brief Assembly of Jacobian for nonlinear Elasticity
+@param[in] dim Dimension
+@param[in] FEType FE Discretization
+@param[in] degree Degree of basis function
+@param[in] A Resulting matrix
+@param[in] callFillComplete If Matrix A should be completely filled at end of function
+@param[in] FELocExternal 
+
+*/				
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyNonLinearElasticity(int dim,
+	                                    std::string FEType,
+	                                    int degree,
+										int dofs,
+										MultiVectorPtr_Type d_rep,
+	                                    BlockMatrixPtr_Type &A,
+										BlockMultiVectorPtr_Type &resVec,
+ 										ParameterListPtr_Type params, 									
+                                        DomainConstPtr_Type domain,
+                                        MultiVectorPtr_Type eModVec,
+	                                    bool callFillComplete,
+	                                    int FELocExternal){
+	
+	ElementsPtr_Type elements = domain->getElementsC();
+
+	int dofsElement = elements->getElement(0).getVectorNodeList().size();
+
+	vec2D_dbl_ptr_Type pointsRep = domain->getPointsRepeated();
+
+	MapConstPtr_Type map = domain->getMapRepeated();
+
+	vec_dbl_Type solution(0);
+	vec_dbl_Type solution_d;
+
+	vec_dbl_ptr_Type rhsVec;
+
+	/// Tupel construction follows follwing pattern:
+	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
+	int numNodes=6;
+	if(dim==3){
+		numNodes=10;
+	}
+	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
+	tuple_ssii_Type displacement ("Displacement",FEType,dofs,numNodes);
+	problemDisk->push_back(displacement);
+
+    int neoHookeNum = params->sublist("Parameter").get("Neo-Hooke Modell",1);
+
+    std::string nonLinElasModell = "NonLinearElasticity2";
+    if(neoHookeNum == 1)
+        nonLinElasModell = "NonLinearElasticity";
+
+    //std::cout << " ######## Assembly Modell: " << nonLinElasModell << " ############ " <<  std::endl;
+
+	if(assemblyFEElements_.size()== 0)
+	 	initAssembleFEElements(nonLinElasModell,problemDisk,elements, params,pointsRep,domain->getElementMap());
+	else if(assemblyFEElements_.size() != elements->numberElements())
+	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
+	
+    Teuchos::ArrayRCP<SC>  eModVecA = eModVec->getDataNonConst(0);
+
+ 	SmallMatrixPtr_Type elementMatrix;
+	for (UN T=0; T<assemblyFEElements_.size(); T++) {
+		vec_dbl_Type solution(0);
+
+		solution_d = getSolution(elements->getElement(T).getVectorNodeList(), d_rep,dofs);
+
+		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
+
+		assemblyFEElements_[T]->updateSolution(solution);
+        assemblyFEElements_[T]->updateParameter("E",eModVecA[T]);
+        assemblyFEElements_[T]->assembleJacobian();
+        elementMatrix = assemblyFEElements_[T]->getJacobian();              
+        addFeBlock(A, elementMatrix, elements->getElement(T), map, 0, 0, problemDisk);
+
+        assemblyFEElements_[T]->assembleRHS();
+        rhsVec = assemblyFEElements_[T]->getRHS(); 
+        addFeBlockMv(resVec, rhsVec, elements->getElement(T),  dofs);
+
+        assemblyFEElements_[T]->advanceNewtonStep();
+
+
+	}
+	if (callFillComplete)
+	    A->getBlock(0,0)->fillComplete( domainVec_.at(0)->getMapVecFieldUnique(),domainVec_.at(0)->getMapVecFieldUnique());
+	
+}
+
+
+/*!
+
+ \brief Inserting local rhsVec into global residual Mv;
+
+
+@param[in] res BlockMultiVector of residual vec; Repeated distribution; 2 blocks
+@param[in] rhsVec sorted the same way as residual vec
+@param[in] element of block1
+
+*/
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec, FiniteElement elementBlock, int dofs){
+
+    Teuchos::ArrayRCP<SC>  resArray_block = res->getBlockNonConst(0)->getDataNonConst(0);
+
+	vec_LO_Type nodeList_block = elementBlock.getVectorNodeList();
+
+	for(int i=0; i< nodeList_block.size() ; i++){
+		for(int d=0; d<dofs; d++)
+			resArray_block[nodeList_block[i]*dofs+d] += (*rhsVec)[i*dofs+d];
+	}
+}
+
+// Check the order of chemistry and solid in system matrix
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyAceDeformDiffu(int dim,
+                        std::string FETypeChem,
+                        std::string FETypeSolid,
+                        int degree,
+                        int dofsChem,
+                        int dofsSolid,
+                        MultiVectorPtr_Type c_rep,
+                        MultiVectorPtr_Type d_rep,
+                        BlockMatrixPtr_Type &A,
+                        BlockMultiVectorPtr_Type &resVec,
+                        ParameterListPtr_Type params,
+                        std::string assembleMode,
+                        bool callFillComplete,
+                        int FELocExternal){
+
+    if((FETypeChem != "P2") || (FETypeSolid != "P2") || dim != 3)
+    	TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "No AceGen Implementation available for Discretization and Dimension." );
+
+
+    UN FElocChem = 1; //checkFE(dim,FETypeChem); // Checks for different domains which belongs to a certain fetype
+    UN FElocSolid = 0; //checkFE(dim,FETypeSolid); // Checks for different domains which belongs to a certain fetype
+
+	ElementsPtr_Type elementsChem= domainVec_.at(FElocChem)->getElementsC();
+
+	ElementsPtr_Type elementsSolid = domainVec_.at(FElocSolid)->getElementsC();
+
+    //this->domainVec_.at(FElocChem)->info();
+    //this->domainVec_.at(FElocSolid)->info();
+	//int dofsElement = elements->getElement(0).getVectorNodeList().size();
+
+	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FElocSolid)->getPointsRepeated();
+
+	MapConstPtr_Type mapChem = domainVec_.at(FElocChem)->getMapRepeated();
+
+	MapConstPtr_Type mapSolid = domainVec_.at(FElocSolid)->getMapRepeated();
+
+	vec_dbl_Type solution_c;
+	vec_dbl_Type solution_d;
+
+	vec_dbl_ptr_Type rhsVec;
+
+	/// Tupel construction follows follwing pattern:
+	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
+	int numChem=3;
+    if(FETypeChem == "P2"){
+        numChem=6;
+    }    
+	if(dim==3){
+		numChem=4;
+        if(FETypeChem == "P2")
+            numChem=10;
+	}
+    int numSolid=3;
+    if(FETypeSolid == "P2")
+        numSolid=6;
+        
+	if(dim==3){
+		numSolid=4;
+        if(FETypeSolid == "P2")
+            numSolid=10;
+	}
+	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
+	tuple_ssii_Type chem ("Chemistry",FETypeChem,dofsChem,numChem);
+	tuple_ssii_Type solid ("Solid",FETypeSolid,dofsSolid,numSolid);
+	problemDisk->push_back(solid);
+	problemDisk->push_back(chem);
+
+	tuple_disk_vec_ptr_Type problemDiskChem = Teuchos::rcp(new tuple_disk_vec_Type(0));
+    problemDiskChem->push_back(chem);
+
+	std::string SCIModel = params->sublist("Parameter").get("Structure Model","SCI_simple");
+
+	if(assemblyFEElements_.size()== 0){
+       	initAssembleFEElements(SCIModel,problemDisk,elementsChem, params,pointsRep,domainVec_.at(FElocSolid)->getElementMap());
+    }
+	else if(assemblyFEElements_.size() != elementsChem->numberElements())
+	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
+
+	//SmallMatrixPtr_Type elementMatrix =Teuchos::rcp( new SmallMatrix_Type( dofsElement));
+
+	MultiVectorPtr_Type resVec_c = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocChem)->getMapRepeated(), 1 ) );
+    MultiVectorPtr_Type resVec_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocSolid)->getMapVecFieldRepeated(), 1 ) );
+	
+	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 2) );
+    resVecRep->addBlock(resVec_d,0);
+    resVecRep->addBlock(resVec_c,1);
+   
+    SC detB;
+    SC absDetB;
+    SmallMatrix<SC> B(dim);
+    SmallMatrix<SC> Binv(dim);
+
+
+    for (UN T=0; T<assemblyFEElements_.size(); T++) {
+		vec_dbl_Type solution(0);
+
+		solution_c = getSolution(elementsChem->getElement(T).getVectorNodeList(), c_rep,dofsChem);
+		solution_d = getSolution(elementsSolid->getElement(T).getVectorNodeList(), d_rep,dofsSolid);
+
+        // First Solid, then Chemistry
+		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
+		solution.insert( solution.end(), solution_c.begin(), solution_c.end() );
+        
+  		assemblyFEElements_[T]->updateSolution(solution);
+
+ 		SmallMatrixPtr_Type elementMatrix;
+
+        // ------------------------
+        /*buildTransformation(elementsSolid->getElement(T).getVectorNodeList(), pointsRep, B, FETypeSolid);
+        detB = B.computeInverse(Binv);
+        absDetB = std::fabs(detB);
+        std::cout << " Determinante " << detB << std::endl;*/
+        // ------------------------
+
+
+
+
+		if(assembleMode == "Jacobian"){
+			assemblyFEElements_[T]->assembleJacobian();
+
+            elementMatrix = assemblyFEElements_[T]->getJacobian(); 
+           // elementMatrix->print();
+			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
+			
+			addFeBlockMatrix(A, elementMatrix, elementsSolid->getElement(T), elementsSolid->getElement(T), mapSolid, mapChem, problemDisk);
+
+          
+
+		}
+		if(assembleMode == "Rhs"){
+		    assemblyFEElements_[T]->assembleRHS();
+		    rhsVec = assemblyFEElements_[T]->getRHS(); 
+			addFeBlockMv(resVecRep, rhsVec, elementsSolid->getElement(T),elementsChem->getElement(T), dofsSolid,dofsChem);
+
+		}
+        if(assembleMode=="MassMatrix"){
+            assemblyFEElements_[T]->assembleJacobian();
+
+            AssembleFE_SCI_SMC_Active_Growth_Reorientation_Ptr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFE_SCI_SMC_Active_Growth_Reorientation_Type>(assemblyFEElements_[T] );
+            elTmp->getMassMatrix(elementMatrix);
+            //elementMatrix->print();
+   			addFeBlock(A, elementMatrix, elementsChem->getElement(T), mapChem, 0, 0, problemDiskChem);
+
+
+        }
+
+        
+
+			
+	}
+	if ( assembleMode == "Jacobian"){
+		A->getBlock(0,0)->fillComplete();
+	    A->getBlock(1,0)->fillComplete(domainVec_.at(FElocSolid)->getMapVecFieldUnique(),domainVec_.at(FElocChem)->getMapUnique());
+	    A->getBlock(0,1)->fillComplete(domainVec_.at(FElocChem)->getMapUnique(),domainVec_.at(FElocSolid)->getMapVecFieldUnique());
+	    A->getBlock(1,1)->fillComplete();
+	}
+    else if(assembleMode == "Rhs"){
+
+		MultiVectorPtr_Type resVecUnique_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocSolid)->getMapVecFieldUnique(), 1 ) );
+		MultiVectorPtr_Type resVecUnique_c = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocChem)->getMapUnique(), 1 ) );
+
+		resVecUnique_d->putScalar(0.);
+		resVecUnique_c->putScalar(0.);
+
+		resVecUnique_d->exportFromVector( resVec_d, true, "Add" );
+		resVecUnique_c->exportFromVector( resVec_c, true, "Add" );
+
+		resVec->addBlock(resVecUnique_d,0);
+		resVec->addBlock(resVecUnique_c,1);
+	}
+    else if(assembleMode == "MassMatrix"){
+   		A->getBlock(0,0)->fillComplete();
+    }
+
+}
+
+// Check the order of chemistry and solid in system matrix
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyAceDeformDiffuBlock(int dim,
+                        std::string FETypeChem,
+                        std::string FETypeSolid,
+                        int degree,
+                        int dofsChem,
+                        int dofsSolid,
+                        MultiVectorPtr_Type c_rep,
+                        MultiVectorPtr_Type d_rep,
+                        BlockMatrixPtr_Type &A,
+                        int blockRow,
+                        int blockCol,
+                        BlockMultiVectorPtr_Type &resVec,
+                        int block,
+                        ParameterListPtr_Type params,
+                        std::string assembleMode,
+                        bool callFillComplete,
+                        int FELocExternal){
+
+    if((FETypeChem != "P2") || (FETypeSolid != "P2") || dim != 3)
+    	TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "No AceGen Implementation available for Discretization and Dimension." );
+    if((blockRow != blockCol) && blockRow != 0)
+        TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Block assemblyDeformDiffu AceGEN Version only implemented for 0,0 block right now" );
+
+    //UN FElocChem = 1; //checkFE(dim,FETypeChem); // Checks for different domains which belongs to a certain fetype
+    UN FElocSolid = 0; //checkFE(dim,FETypeSolid); // Checks for different domains which belongs to a certain fetype
+
+	ElementsPtr_Type elementsChem= domainVec_.at(FElocSolid)->getElementsC();
+
+	ElementsPtr_Type elementsSolid = domainVec_.at(FElocSolid)->getElementsC();
+
+    //this->domainVec_.at(FElocChem)->info();
+    //this->domainVec_.at(FElocSolid)->info();
+	//int dofsElement = elements->getElement(0).getVectorNodeList().size();
+
+	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FElocSolid)->getPointsRepeated();
+
+	//MapConstPtr_Type mapChem = domainVec_.at(FElocChem)->getMapRepeated();
+
+	MapConstPtr_Type mapSolid = domainVec_.at(FElocSolid)->getMapRepeated();
+
+	vec_dbl_Type solution_c;
+	vec_dbl_Type solution_d;
+
+	vec_dbl_ptr_Type rhsVec;
+
+	/// Tupel construction follows follwing pattern:
+	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
+	int numChem=3;
+    if(FETypeChem == "P2"){
+        numChem=6;
+    }    
+	if(dim==3){
+		numChem=4;
+        if(FETypeChem == "P2")
+            numChem=10;
+	}
+    int numSolid=3;
+    if(FETypeSolid == "P2")
+        numSolid=6;
+        
+	if(dim==3){
+		numSolid=4;
+        if(FETypeSolid == "P2")
+            numSolid=10;
+	}
+	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
+	tuple_ssii_Type chem ("Chemistry",FETypeChem,dofsChem,numChem);
+	tuple_ssii_Type solid ("Solid",FETypeSolid,dofsSolid,numSolid);
+	problemDisk->push_back(solid);
+	problemDisk->push_back(chem);
+	
+	std::string SCIModel = params->sublist("Parameter").get("Structure Model","SCI_simple");
+
+	if(assemblyFEElements_.size()== 0){
+       	initAssembleFEElements(SCIModel,problemDisk,elementsChem, params,pointsRep,domainVec_.at(FElocSolid)->getElementMap());
+    }
+	else if(assemblyFEElements_.size() != elementsChem->numberElements())
+	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
+
+	//SmallMatrixPtr_Type elementMatrix =Teuchos::rcp( new SmallMatrix_Type( dofsElement));
+
+	//MultiVectorPtr_Type resVec_c = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocChem)->getMapRepeated(), 1 ) );
+    MultiVectorPtr_Type resVec_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocSolid)->getMapVecFieldRepeated(), 1 ) );
+	
+	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 1) );
+    resVecRep->addBlock(resVec_d,0);
+    //resVecRep->addBlock(resVec_c,1);
+
+    for (UN T=0; T<assemblyFEElements_.size(); T++) {
+		vec_dbl_Type solution(0);
+
+		solution_c = getSolution(elementsChem->getElement(T).getVectorNodeList(), c_rep,dofsChem);
+		solution_d = getSolution(elementsSolid->getElement(T).getVectorNodeList(), d_rep,dofsSolid);
+
+        // First Solid, then Chemistry
+		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
+		solution.insert( solution.end(), solution_c.begin(), solution_c.end() );
+        
+  		assemblyFEElements_[T]->updateSolution(solution);
+
+ 		SmallMatrixPtr_Type elementMatrix;
+
+		if(assembleMode == "Jacobian"){
+			assemblyFEElements_[T]->assembleJacobian();
+
+            elementMatrix = assemblyFEElements_[T]->getJacobian(); 
+           // elementMatrix->print();
+			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
+			addFeBlock(A, elementMatrix, elementsSolid->getElement(T), mapSolid, 0, 0, problemDisk);
+			//addFeBlockMatrix(A, elementMatrix, elementsSolid->getElement(T),  mapSolid, mapChem, problemDisk);
+		}
+		if(assembleMode == "Rhs"){
+		    assemblyFEElements_[T]->assembleRHS();
+		    rhsVec = assemblyFEElements_[T]->getRHS(); 
+			addFeBlockMv(resVecRep, rhsVec, elementsSolid->getElement(T), dofsSolid);
+		}
+        //if(assembleMode=="compute")
+        //    assemblyFEElements_[T]->compute();
+
+        
+
+			
+	}
+	if ( assembleMode != "Rhs"){
+		A->getBlock(0,0)->fillComplete();
+	    //A->getBlock(1,0)->fillComplete(domainVec_.at(FElocSolid)->getMapVecFieldUnique(),domainVec_.at(FElocChem)->getMapUnique());
+	    //A->getBlock(0,1)->fillComplete(domainVec_.at(FElocChem)->getMapUnique(),domainVec_.at(FElocSolid)->getMapVecFieldUnique());
+	    //A->getBlock(1,1)->fillComplete();
+	}
+
+    if(assembleMode == "Rhs"){
+
+		MultiVectorPtr_Type resVecUnique_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocSolid)->getMapVecFieldUnique(), 1 ) );
+		//MultiVectorPtr_Type resVecUnique_c = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocChem)->getMapUnique(), 1 ) );
+
+		resVecUnique_d->putScalar(0.);
+		//resVecUnique_c->putScalar(0.);
+
+		resVecUnique_d->exportFromVector( resVec_d, true, "Add" );
+		//resVecUnique_c->exportFromVector( resVec_c, true, "Add" );
+
+		resVec->addBlock(resVecUnique_d,0);
+		//resVec->addBlock(resVecUnique_c,1);
+	}
+
+
+}
+/*!
+
+ \brief Inserting element stiffness matrices into global stiffness matrix
+
+
+@param[in] &A Global Block Matrix
+@param[in] elementMatrix Stiffness matrix of one element
+@param[in] element Corresponding finite element
+@param[in] map Map that corresponds to repeated nodes of first block
+@param[in] map Map that corresponds to repeated nodes of second block
+
+*/
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::addFeBlockMatrix(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement element1, FiniteElement element2, MapConstPtr_Type mapFirstRow,MapConstPtr_Type mapSecondRow, tuple_disk_vec_ptr_Type problemDisk){
+		
+		int numDisk = problemDisk->size();
+
+		int dofs1 = std::get<2>(problemDisk->at(0));
+		int dofs2 = std::get<2>(problemDisk->at(1));
+
+		int numNodes1 = std::get<3>(problemDisk->at(0));
+		int numNodes2=std::get<3>(problemDisk->at(1));
+
+		int dofsBlock1 = dofs1*numNodes1;
+		int dofsBlock2  = dofs2*numNodes2;
+
+		Teuchos::Array<SC> value1( numNodes1, 0. );
+        Teuchos::Array<GO> columnIndices1( numNodes1, 0 );
+
+        Teuchos::Array<SC> value2( numNodes2, 0. );
+        Teuchos::Array<GO> columnIndices2( numNodes2, 0 );
+
+		for (UN i=0; i < numNodes1 ; i++) {
+			for(int di=0; di<dofs1; di++){
+				GO row =GO (dofs1* mapFirstRow->getGlobalElement( element1.getNode(i) )+di);
+				for(int d=0; d<dofs1; d++){
+					for (UN j=0; j < columnIndices1.size(); j++){
+		                columnIndices1[j] = GO ( dofs1 * mapFirstRow->getGlobalElement( element1.getNode(j) ) + d );
+						value1[j] = (*elementMatrix)[dofs1*i+di][dofs1*j+d];	
+					}
+			  		A->getBlock(0,0)->insertGlobalValues( row, columnIndices1(), value1() ); // Automatically adds entries if a value already exists 
+				}          
+            }
+		}
+		int offset= numNodes1*dofs1;
+
+
+        Teuchos::Array<SC> value( 1, 0. );
+        Teuchos::Array<GO> columnIndex( 1, 0 );
+        for (UN i=0; i < numNodes2 ; i++) {
+            for(int di=0; di<dofs2; di++){
+                GO row =GO (dofs2* mapSecondRow->getGlobalElement( element2.getNode(i) )+di);
+                for(int d=0; d<dofs2; d++){
+                    for (UN j=0; j < columnIndices2.size(); j++){
+                        double tmpValue =  (*elementMatrix)[offset+dofs2*i+di][offset+dofs2*j+d];
+                        if(std::fabs(tmpValue) > 1.e-13){
+                            columnIndex[0] = GO ( dofs2 * mapSecondRow->getGlobalElement( element2.getNode(j) ) + d );
+                            value[0] = tmpValue;
+                            A->getBlock(1,1)->insertGlobalValues( row, columnIndex(), value() ); // Automatically adds entries if a value already exists 
+
+                        }
+                    }
+                }          
+            }
+        }
+        
+		for (UN i=0; i < numNodes1; i++){
+			for(int di=0; di<dofs1; di++){				
+                GO row =GO (dofs1* mapFirstRow->getGlobalElement( element1.getNode(i) )+di);
+                for(int d=0; d<dofs2; d++){				
+                    for (UN j=0; j < numNodes2 ; j++) {
+                        value2[j] = (*elementMatrix)[i*dofs1+di][offset+j*dofs2+d];			    				    		
+                        columnIndices2[j] =GO (dofs2* mapSecondRow->getGlobalElement( element2.getNode(j) )+d);
+                    }
+                    A->getBlock(0,1)->insertGlobalValues( row, columnIndices2(), value2() ); // Automatically adds entries if a value already exists                            
+                }
+            }      
+		}
+
+        for (UN j=0; j < numNodes2; j++){
+            for(int di=0; di<dofs2; di++){	
+                GO row = GO (dofs2* mapSecondRow->getGlobalElement( element2.getNode(j) ) +di );
+                for(int d=0; d<dofs1; d++){				
+                    for (UN i=0; i < numNodes1 ; i++) {
+                        value1[i] = (*elementMatrix)[offset+j*dofs2+di][dofs1*i+d];			    				    		
+                        columnIndices1[i] =GO (dofs1* mapFirstRow->getGlobalElement( element1.getNode(i) )+d);
+                    }
+                    A->getBlock(1,0)->insertGlobalValues( row, columnIndices1(), value1() ); // Automatically adds entries if a value already exists                       
+                }    
+            }  
+		}
+
+
+}
+
+
+/*!
+
+ \brief Assembly of Jacobian for NavierStokes 
+@param[in] dim Dimension
+@param[in] FEType FE Discretization
+@param[in] degree Degree of basis function
+@param[in] A Resulting matrix
+@param[in] callFillComplete If Matrix A should be completely filled at end of function
+@param[in] FELocExternal 
+
+*/
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyNavierStokes(int dim,
+	                                    std::string FETypeVelocity,
+	                                    std::string FETypePressure,
+	                                    int degree,
+										int dofsVelocity,
+										int dofsPressure,
+										MultiVectorPtr_Type u_rep,
+										MultiVectorPtr_Type p_rep,
+	                                    BlockMatrixPtr_Type &A,
+										BlockMultiVectorPtr_Type &resVec,
+										SmallMatrix_Type coeff,
+ 										ParameterListPtr_Type params,
+ 										bool reAssemble,
+ 										std::string assembleMode,
+	                                    bool callFillComplete,
+	                                    int FELocExternal){
+	
+
+    UN FElocVel = checkFE(dim,FETypeVelocity); // Checks for different domains which belongs to a certain fetype
+    UN FElocPres = checkFE(dim,FETypePressure); // Checks for different domains which belongs to a certain fetype
+
+	ElementsPtr_Type elements = domainVec_.at(FElocVel)->getElementsC();
+
+	ElementsPtr_Type elementsPres = domainVec_.at(FElocPres)->getElementsC();
+
+	int dofsElement = elements->getElement(0).getVectorNodeList().size();
+
+	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FElocVel)->getPointsRepeated();
+
+	MapConstPtr_Type mapVel = domainVec_.at(FElocVel)->getMapRepeated();
+
+	MapConstPtr_Type mapPres = domainVec_.at(FElocPres)->getMapRepeated();
+
+	vec_dbl_Type solution(0);
+	vec_dbl_Type solution_u;
+	vec_dbl_Type solution_p;
+
+	vec_dbl_ptr_Type rhsVec;
+
+	/// Tupel construction follows follwing pattern:
+	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
+	int numVelo=3;
+    if(FETypeVelocity == "P2")
+        numVelo=6;
+        
+	if(dim==3){
+		numVelo=4;
+        if(FETypeVelocity == "P2")
+            numVelo=10;
+	}
+	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
+	tuple_ssii_Type vel ("Velocity",FETypeVelocity,dofsVelocity,numVelo);
+	tuple_ssii_Type pres ("Pressure",FETypePressure,dofsPressure,dim+1);
+	problemDisk->push_back(vel);
+	problemDisk->push_back(pres);
+
+	if(assemblyFEElements_.size()== 0){
+        if(params->sublist("Material").get("Newtonian",true) == false)
+	 	    initAssembleFEElements("GeneralizedNewtonian",problemDisk,elements, params,pointsRep,domainVec_.at(FElocVel)->getElementMap()); // In cas of non Newtonian Fluid
+        else
+        	initAssembleFEElements("NavierStokes",problemDisk,elements, params,pointsRep,domainVec_.at(FElocVel)->getElementMap());
+    }
+	else if(assemblyFEElements_.size() != elements->numberElements())
+	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
+
+	//SmallMatrixPtr_Type elementMatrix =Teuchos::rcp( new SmallMatrix_Type( dofsElement));
+
+	MultiVectorPtr_Type resVec_u = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocVel)->getMapVecFieldRepeated(), 1 ) );
+    MultiVectorPtr_Type resVec_p = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocPres)->getMapRepeated(), 1 ) );
+	
+	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 2) );
+	resVecRep->addBlock(resVec_u,0);
+	resVecRep->addBlock(resVec_p,1);
+
+
+	for (UN T=0; T<assemblyFEElements_.size(); T++) {
+		vec_dbl_Type solution(0);
+
+		solution_u = getSolution(elements->getElement(T).getVectorNodeList(), u_rep,dofsVelocity);
+		solution_p = getSolution(elementsPres->getElement(T).getVectorNodeList(), p_rep,dofsPressure);
+
+		solution.insert( solution.end(), solution_u.begin(), solution_u.end() );
+		solution.insert( solution.end(), solution_p.begin(), solution_p.end() );
+
+		assemblyFEElements_[T]->updateSolution(solution);
+ 
+ 		SmallMatrixPtr_Type elementMatrix;
+
+		if(assembleMode == "Jacobian"){
+			assemblyFEElements_[T]->assembleJacobian();
+		    
+            elementMatrix = assemblyFEElements_[T]->getJacobian(); 
+
+			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
+
+			if(reAssemble)
+				addFeBlock(A, elementMatrix, elements->getElement(T), mapVel, 0, 0, problemDisk);
+			else
+				addFeBlockMatrix(A, elementMatrix, elements->getElement(T), elementsPres->getElement(T), mapVel, mapPres, problemDisk);
+		}
+   		if(assembleMode == "FixedPoint"){
+            
+            //AssembleFENavierStokesPtr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFENavierStokes_Type>(assemblyFEElements_[T] ); // Why should we need a pointer we can directly call it using assemblyFEElements_[T]? Because assemblyFixedPoint is not a function of base class
+
+            if(params->sublist("Material").get("Newtonian",true) == false)
+            {
+                AssembleFEGeneralizedNewtonianPtr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFEGeneralizedNewtonian_Type>( assemblyFEElements_[T] );
+                elTmp->assembleFixedPoint();
+                elementMatrix =  elTmp->getFixedPointMatrix(); 
+            }
+            else // Newtonian Case
+            {
+              AssembleFENavierStokesPtr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFENavierStokes_Type>( assemblyFEElements_[T] );
+              elTmp->assembleFixedPoint();
+              elementMatrix =  elTmp->getFixedPointMatrix(); 
+            }
+            
+
+			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
+
+			if(reAssemble)
+				addFeBlock(A, elementMatrix, elements->getElement(T), mapVel, 0, 0, problemDisk);
+			else
+				addFeBlockMatrix(A, elementMatrix, elements->getElement(T), elementsPres->getElement(T),mapVel, mapPres, problemDisk);
+
+        }
+		if(assembleMode == "Rhs"){
+			AssembleFENavierStokesPtr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFENavierStokes_Type>(assemblyFEElements_[T] );
+			elTmp->setCoeff(coeff);// Coeffs from time discretization. Right now default [1][1] // [0][0]
+		    assemblyFEElements_[T]->assembleRHS();
+		    rhsVec = assemblyFEElements_[T]->getRHS(); 
+			addFeBlockMv(resVecRep, rhsVec, elements->getElement(T),elementsPres->getElement(T), dofsVelocity,dofsPressure);
+		}
+
+			
+	}
+	if (callFillComplete && reAssemble && assembleMode != "Rhs" )
+	    A->getBlock(0,0)->fillComplete( domainVec_.at(FElocVel)->getMapVecFieldUnique(),domainVec_.at(FElocVel)->getMapVecFieldUnique());
+	else if(callFillComplete && !reAssemble && assembleMode != "Rhs"){
+		A->getBlock(0,0)->fillComplete();
+	    A->getBlock(1,0)->fillComplete(domainVec_.at(FElocVel)->getMapVecFieldUnique(),domainVec_.at(FElocPres)->getMapUnique());
+	    A->getBlock(0,1)->fillComplete(domainVec_.at(FElocPres)->getMapUnique(),domainVec_.at(FElocVel)->getMapVecFieldUnique());
+	}
+
+	if(assembleMode == "Rhs"){
+
+		MultiVectorPtr_Type resVecUnique_u = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocVel)->getMapVecFieldUnique(), 1 ) );
+		MultiVectorPtr_Type resVecUnique_p = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocPres)->getMapUnique(), 1 ) );
+
+		resVecUnique_u->putScalar(0.);
+		resVecUnique_p->putScalar(0.);
+
+		resVecUnique_u->exportFromVector( resVec_u, true, "Add" );
+		resVecUnique_p->exportFromVector( resVec_p, true, "Add" );
+
+		resVec->addBlock(resVecUnique_u,0);
+		resVec->addBlock(resVecUnique_p,1);
+	}
+
+
+}
+
+
+/*!
+ \brief  Method to loop over all assembleFESpecific elements and set the defined linearization 
+@param[in] string linearization e.g. "Picard" or "Newton"
+*/
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::changeLinearizationFE(std::string linearization)
+{
+    for (UN T=0; T<assemblyFEElements_.size(); T++) // For each assembledFEElement change Linearization
+    {	
+        assemblyFEElements_[T]->changeLinearization(linearization);
+    }
+}
+
+
+/*!
+ \brief Postprocessing: Using a converged velocity solution -> compute averaged viscosity inside an element at center of mass
+@param[in] dim Dimension
+@param[in] FEType FE Discretization
+@param[in] degree Degree of basis function
+@param[in] repeated solution fields for u and p
+@param[in] parameter lists
+*/
+
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::computeSteadyViscosityFE_CM(int dim,
+	                                    std::string FETypeVelocity,
+	                                    std::string FETypePressure,
+										int dofsVelocity,
+										int dofsPressure,
+										MultiVectorPtr_Type u_rep,
+										MultiVectorPtr_Type p_rep,
+ 										ParameterListPtr_Type params){
+	
+
+    UN FElocVel = checkFE(dim,FETypeVelocity); // Checks for different domains which belongs to a certain fetype
+    UN FElocPres = checkFE(dim,FETypePressure); // Checks for different domains which belongs to a certain fetype
+
+	ElementsPtr_Type elements = domainVec_.at(FElocVel)->getElementsC();
+	ElementsPtr_Type elementsPres = domainVec_.at(FElocPres)->getElementsC();
+
+	vec_dbl_Type solution(0);
+	vec_dbl_Type solution_u;
+	vec_dbl_Type solution_p;
+    vec_dbl_Type solution_viscosity;
+
+    // We have to compute viscosity solution in each element 
+	MultiVectorPtr_Type Sol_viscosity = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocVel)->getElementMap(), 1 ) ); //
+    BlockMultiVectorPtr_Type visco_output = Teuchos::rcp( new BlockMultiVector_Type(1) );
+    visco_output->addBlock(Sol_viscosity,0);
+   
+
+	for (UN T=0; T<assemblyFEElements_.size(); T++) {
+       
+		vec_dbl_Type solution(0);
+		solution_u = getSolution(elements->getElement(T).getVectorNodeList(), u_rep,dofsVelocity); // get the solution inside an element on the nodes
+		solution_p = getSolution(elementsPres->getElement(T).getVectorNodeList(), p_rep,dofsPressure);
+
+		solution.insert( solution.end(), solution_u.begin(), solution_u.end() ); // here we insert the solution
+		solution.insert( solution.end(), solution_p.begin(), solution_p.end() );
+
+		assemblyFEElements_[T]->updateSolution(solution); // here we update the value of the solutions inside an element
+ 
+        assemblyFEElements_[T]->computeLocalconstOutputField(); //  we compute the viscosity inside an element
+        solution_viscosity = assemblyFEElements_[T]->getLocalconstOutputField();
+
+        Teuchos::ArrayRCP<SC>  resArray_block = visco_output->getBlockNonConst(0)->getDataNonConst(0); // First 
+        resArray_block[T] = solution_viscosity[0]; // although it is a vector it only has one entry because we compute the value in the center of the element
+          
+	} // end loop over all elements
+    // We could also instead of just overwrite it add an aditional block such that we could also compute other output fields and save it in there
+    this->const_output_fields= visco_output;
+
+
+}
+
+
+
+/*!
+
+ \brief Inserting local rhsVec into global residual Mv;
+
+
+@param[in] res BlockMultiVector of residual vec; Repeated distribution; 2 blocks
+@param[in] rhsVec sorted the same way as residual vec
+@param[in] element of block1
+
+*/
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec, FiniteElement elementBlock1,FiniteElement elementBlock2, int dofs1, int dofs2 ){
+
+    Teuchos::ArrayRCP<SC>  resArray_block1 = res->getBlockNonConst(0)->getDataNonConst(0);
+
+    Teuchos::ArrayRCP<SC>  resArray_block2 = res->getBlockNonConst(1)->getDataNonConst(0);
+
+	vec_LO_Type nodeList_block1 = elementBlock1.getVectorNodeList();
+
+	vec_LO_Type nodeList_block2 = elementBlock2.getVectorNodeList();
+
+	for(int i=0; i< nodeList_block1.size() ; i++){
+		for(int d=0; d<dofs1; d++){
+			resArray_block1[nodeList_block1[i]*dofs1+d] += (*rhsVec)[i*dofs1+d];
+        }
+	}
+	int offset = nodeList_block1.size()*dofs1;
+
+	for(int i=0; i < nodeList_block2.size(); i++){
+		for(int d=0; d<dofs2; d++)
+			resArray_block2[nodeList_block2[i]*dofs2+d] += (*rhsVec)[i*dofs2+d+offset];
+	}
+
+}
+
+
+/*!
+
+ \brief Adding FEBlock (row,column) to FE Blockmatrix
+TODO: column indices pre determine
+
+@param[in] &A Global Block Matrix
+@param[in] elementMatrix Stiffness matrix of one element
+@param[in] element Corresponding finite element
+@param[in] map Map that corresponds to repeated nodes of first block
+@param[in] map Map that corresponds to repeated nodes of second block
+
+*/
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::addFeBlock(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement element, MapConstPtr_Type mapRow, int row, int column, tuple_disk_vec_ptr_Type problemDisk){
+		
+		int dofs1 = std::get<2>(problemDisk->at(row));
+
+		int numNodes1 = std::get<3>(problemDisk->at(row));
+
+		int dofsBlock1 = dofs1*numNodes1;
+
+		Teuchos::Array<SC> value( numNodes1, 0. );
+        Teuchos::Array<GO> columnIndices( numNodes1, 0 );
+
+		for (UN i=0; i < numNodes1 ; i++) {
+			for(int di=0; di<dofs1; di++){
+				GO rowID =GO (dofs1* mapRow->getGlobalElement( element.getNode(i) )+di);
+				for(int d=0; d<dofs1; d++){
+					for (UN j=0; j < columnIndices.size(); j++){
+		                columnIndices[j] = GO ( dofs1 * mapRow->getGlobalElement( element.getNode(j) ) + d );
+						value[j] = (*elementMatrix)[dofs1*i+di][dofs1*j+d];	
+					}
+			  		A->getBlock(row,column)->insertGlobalValues( rowID, columnIndices(), value() ); // Automatically adds entries if a value already exists 
+				}          
+            }
+		}
+}
+
+/*!
+
+ \brief Initialization of vector consisting of the assembleFE Elements. Follows structure of 'normal' elements, i.e. elementMap also applicable
+
+@param[in] elementType i.e. Laplace, Navier Stokes..
+@param[in] problemDisk Tuple of specific problem Information
+@param[in] elements
+@param[in] params parameter list
+
+*/
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::initAssembleFEElements(std::string elementType,tuple_disk_vec_ptr_Type problemDisk,ElementsPtr_Type elements, ParameterListPtr_Type params,vec2D_dbl_ptr_Type pointsRep, MapConstPtr_Type elementMap){
+    
+	vec2D_dbl_Type nodes;
+	for (UN T=0; T<elements->numberElements(); T++) {
+		
+		nodes = getCoordinates(elements->getElement(T).getVectorNodeList(), pointsRep);
+
+		AssembleFEFactory<SC,LO,GO,NO> assembleFEFactory;
+
+		AssembleFEPtr_Type assemblyFE = assembleFEFactory.build(elementType,elements->getElement(T).getFlag(),nodes, params,problemDisk);
+        //  
+        assemblyFE->setGlobalElementID(elementMap->getGlobalElement(T));
+
+		assemblyFEElements_.push_back(assemblyFE);
+
+	}
+
+}
+
+/*!
+
+ \brief Returns coordinates of local node ids
+
+@param[in] localIDs
+@param[in] points
+@param[out] coordinates 
+
+*/
+
+template <class SC, class LO, class GO, class NO>
+vec2D_dbl_Type FE_ElementAssembly<SC,LO,GO,NO>::getCoordinates(vec_LO_Type localIDs, vec2D_dbl_ptr_Type points){
+
+	vec2D_dbl_Type coordinates(0,vec_dbl_Type( points->at(0).size()));
+	for(int i=0; i < localIDs.size() ; i++){
+		coordinates.push_back(points->at(localIDs[i]));
+	}
+
+    return coordinates;
+}
+
+/*!
+
+ \brief Returns entries of u of element
+
+@param[in] localIDs
+@param[in] points
+@param[out] coordinates 
+
+*/
+
+template <class SC, class LO, class GO, class NO>
+vec_dbl_Type FE_ElementAssembly<SC,LO,GO,NO>::getSolution(vec_LO_Type localIDs, MultiVectorPtr_Type u_rep, int dofsVelocity){
+
+    Teuchos::ArrayRCP<SC>  uArray = u_rep->getDataNonConst(0);
+	
+	vec_dbl_Type solution(0);
+	for(int i=0; i < localIDs.size() ; i++){
+		for(int d=0; d<dofsVelocity; d++)
+			solution.push_back(uArray[localIDs[i]*dofsVelocity+d]);
+	}
+
+    return solution;
+}
+
+
+    
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyEmptyMatrix(MatrixPtr_Type &A){
+    A->fillComplete();
+}
+
+
+
+/*!
+ \brief Assembly of constant stiffness matix for laplacian operator \f$ \Delta \f$
+@param[in] dim Dimension
+@param[in] FEType FE Discretization
+@param[in] degree Degree of basis function
+@param[in] A Resulting matrix
+@param[in] callFillComplete If Matrix A should be completely filled at end of function
+@param[in] FELocExternal 
+*/
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyLaplaceAssFE(int dim,
+                                        std::string FEType,
+                                        int degree,
+                                        int dofs,
+                                        BlockMatrixPtr_Type &A,
+                                        bool callFillComplete,
+                                        int FELocExternal){
+    ParameterListPtr_Type params = Teuchos::getParametersFromXmlFile("parametersProblemLaplace.xml");
+
+    UN FEloc = checkFE(dim,FEType);
+    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    vec2D_dbl_Type nodes;
+    int numNodes=dim+1;
+    if(FEType == "P2"){
+        numNodes= 6;
+        if(dim==3)
+            numNodes=10;
+    }
+    tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
+    tuple_ssii_Type vel ("Laplace",FEType,dofs,numNodes); 
+    problemDisk->push_back(vel);
+    if(assemblyFEElements_.size()== 0)
+        initAssembleFEElements("Laplace",problemDisk,elements, params,pointsRep,domainVec_.at(0)->getElementMap());
+    else if(assemblyFEElements_.size() != elements->numberElements())
+         TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
+    for (UN T=0; T<elements->numberElements(); T++) {
+        assemblyFEElements_[T]->assembleJacobian();
+        SmallMatrixPtr_Type elementMatrix = assemblyFEElements_[T]->getJacobian(); 
+      	addFeBlock(A, elementMatrix, elements->getElement(T), map, 0, 0, problemDisk);
+
+    }
+    if(callFillComplete)
+        A->getBlock(0,0)->fillComplete();
+}
+
+
+
+/*!
+ \brief Assembly of Jacobian for nonlinear Laplace example
+@param[in] dim Dimension
+@param[in] FEType FE Discretization
+@param[in] degree Degree of basis function
+@param[in] u_rep The current solution
+@param[in] A Resulting matrix
+@param[in] resVec Resulting residual
+@param[in] params Params needed by the problem. Placeholder for now.
+@param[in] assembleMode What should be assembled i.e. Rhs (residual) or the
+Jacobian
+@param[in] callFillComplete If Matrix A should be redistributed across MPI procs
+at end of function
+@param[in] FELocExternal ?
+*/
+
+template <class SC, class LO, class GO, class NO>
+void FE_ElementAssembly<SC,LO,GO,NO>::assemblyNonlinearLaplace(
+    int dim, std::string FEType, int degree, MultiVectorPtr_Type u_rep,
+    BlockMatrixPtr_Type &A, BlockMultiVectorPtr_Type &resVec,
+    ParameterListPtr_Type params, std::string assembleMode, bool callFillComplete,
+    int FELocExternal) {
+
+    ElementsPtr_Type elements = this->domainVec_.at(0)->getElementsC();
+
+    // Only scalar laplace
+    int dofs = 1;
+
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(0)->getPointsRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(0)->getMapRepeated();
+
+    vec_dbl_Type solution_u;
+    vec_dbl_ptr_Type rhsVec;
+
+    int numNodes = 3;
+    if (FEType == "P2") {
+        numNodes = 6;
+    }
+    if (dim == 3) {
+        numNodes = 4;
+        if (FEType == "P2") {
+            numNodes = 10;
+        }
+    }
+
+    // Tupel construction follows follwing pattern:
+    // std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e.
+    // "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per
+    // element)
+    tuple_disk_vec_ptr_Type problemDisk =
+        Teuchos::rcp(new tuple_disk_vec_Type(0));
+    tuple_ssii_Type temp("Solution", FEType, dofs, numNodes);
+    problemDisk->push_back(temp);
+
+    // Construct an assembler for each element if not already done
+    if (assemblyFEElements_.size() == 0) {
+        initAssembleFEElements("NonLinearLaplace", problemDisk, elements, params, pointsRep, domainVec_.at(0)->getElementMap());
+    } else if (assemblyFEElements_.size() != elements->numberElements()) {
+        TEUCHOS_TEST_FOR_EXCEPTION(
+            true, std::logic_error,
+            "Number Elements not the same as number assembleFE elements.");
+    }
+
+    MultiVectorPtr_Type resVec_u;
+    BlockMultiVectorPtr_Type resVecRep;
+
+    if (assembleMode != "Rhs") {
+        // add new or overwrite existing block (0,0) of system matrix
+        // This is done in specific problem class for most other problems
+        // Placing it here instead as more fitting
+        auto A_block_zero_zero = Teuchos::rcp(
+            new Matrix_Type(this->domainVec_.at(0)->getMapUnique(), this->domainVec_.at(0)->getApproxEntriesPerRow()));
+
+        A->addBlock(A_block_zero_zero, 0, 0);
+    } else {
+        // Or same for the residual vector
+        resVec_u = Teuchos::rcp(new MultiVector_Type(map, 1));
+        resVecRep = Teuchos::rcp(new BlockMultiVector_Type(1));
+        resVecRep->addBlock(resVec_u, 0);
+    }
+    // Call assembly routines on each element
+    for (UN T = 0; T < assemblyFEElements_.size(); T++) {
+        vec_dbl_Type solution(0);
+
+        // Update solution on the element
+        solution_u = getSolution(elements->getElement(T).getVectorNodeList(),
+                                 u_rep, dofs);
+        solution.insert(solution.end(), solution_u.begin(), solution_u.end());
+        assemblyFEElements_[T]->updateSolution(solution);
+
+        if (assembleMode == "Jacobian") {
+            SmallMatrixPtr_Type elementMatrix;
+            assemblyFEElements_[T]->assembleJacobian();
+            elementMatrix = assemblyFEElements_[T]->getJacobian();
+            // Insert (additive) the local element Jacobian into the global
+            // matrix
+            assemblyFEElements_[T]
+                ->advanceNewtonStep(); // n genereal non linear solver step
+            addFeBlock(A, elementMatrix, elements->getElement(T), map, 0, 0,
+                       problemDisk);
+        }
+
+        if (assembleMode == "Rhs") {
+            assemblyFEElements_[T]->assembleRHS();
+            rhsVec = assemblyFEElements_[T]->getRHS();
+            // Name RHS comes from solving linear systems
+            // For nonlinear systems RHS synonymous to residual
+            // Insert (additive) the updated residual into the global residual
+            // vector
+            addFeBlockMv(resVecRep, rhsVec, elements->getElement(T), dofs);
+        }
+    }
+    if (callFillComplete && assembleMode != "Rhs") {
+        // Signal that editing A has finished. This causes the entries of A to
+        // be redistributed across the MPI ranks
+        A->getBlock(0, 0)->fillComplete(domainVec_.at(0)->getMapUnique(),
+                                        domainVec_.at(0)->getMapUnique());
+    }
+    if (assembleMode == "Rhs") {
+        // Export from overlapping residual to unique residual
+        MultiVectorPtr_Type resVecUnique = Teuchos::rcp(
+            new MultiVector_Type(domainVec_.at(0)->getMapUnique(), 1));
+        resVecUnique->putScalar(0.);
+        resVecUnique->exportFromVector(resVec_u, true, "Add");
+        resVec->addBlock(resVecUnique, 0);
+    }
+}
+
+
+/*!
+ \brief Checks which domain corresponds to certain FE Type and dimension
+ */
+template <class SC, class LO, class GO, class NO>
+int FE_ElementAssembly<SC,LO,GO,NO>::checkFE(int dim,
+                 std::string FEType){
+
+    int FEloc;
+    std::vector<int> matches;
+    for (int i = 0; i < domainVec_.size(); i++) {
+        if (domainVec_.at(i)->getDimension() == dim)
+            matches.push_back(i);
+    }
+
+    bool found = false;
+    for (int i = 0; i < matches.size();i++) {
+        if (domainVec_.at( matches.at(i) )->getFEType() == FEType) {
+            FEloc = matches.at(i);
+            found = true;
+        }
+    }
+
+    TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error   ,"Combination of dimenson(2/3) and FE Type(P1/P2) not defined yet. Use addFE(domain)");
+
+    return FEloc;
+}
+
+}
+#endif

--- a/feddlib/core/FE/FE_decl.hpp
+++ b/feddlib/core/FE/FE_decl.hpp
@@ -1,24 +1,7 @@
 #ifndef FE_DECL_hpp
 #define FE_DECL_hpp
 
-
-#include "feddlib/core/FEDDCore.hpp"
-#include "feddlib/core/General/SmallMatrix.hpp"
-#include "feddlib/core/General/DefaultTypeDefs.hpp"
-#include "feddlib/core/LinearAlgebra/Matrix.hpp"
-#include "feddlib/core/LinearAlgebra/MultiVector.hpp"
-#include "feddlib/core/LinearAlgebra/BlockMatrix.hpp"
-#include "Domain.hpp"
-#include "Helper.hpp"
-#include "sms.hpp"
-#include "feddlib/core/AceFemAssembly/AssembleFE.hpp"
-#include "feddlib/core/AceFemAssembly/specific/AssembleFE_SCI_SMC_Active_Growth_Reorientation.hpp"
-#include "feddlib/core/AceFemAssembly/specific/AssembleFENavierStokes.hpp"
-
-#include "feddlib/core/AceFemAssembly/AssembleFEFactory.hpp"
-
-#include <Teuchos_Array.hpp>
-#include <Teuchos_BLAS.hpp>
+#include "FE_ElementAssembly.hpp"
 
 #include <boost/function.hpp>
 
@@ -44,8 +27,9 @@ class DataElement {
         std::vector<double> hp_;
 };
 
+
 template <class SC = default_sc, class LO = default_lo, class GO = default_go, class NO = default_no>
-class FE {
+class FE: public FE_ElementAssembly<SC,LO,GO,NO> {
   public:
 
     typedef Domain<SC,LO,GO,NO> Domain_Type;
@@ -100,9 +84,6 @@ class FE {
 
 	typedef SmallMatrix<SC> SmallMatrix_Type;
     typedef Teuchos::RCP<SmallMatrix_Type> SmallMatrixPtr_Type;
-
-    DomainConstPtr_vec_Type	domainVec_;
-    Teuchos::RCP<ElementSpec> es_;
 
     /* ###################################################################### */
 
@@ -233,12 +214,6 @@ class FE {
     //                        bool updateHistory=true);
     
     
-    void addFE(DomainConstPtr_Type domain);
-
-    void doSetZeros(double eps = 10*Teuchos::ScalarTraits<SC>::eps());
-
-    void assemblyEmptyMatrix(MatrixPtr_Type &A);
-
     void applyBTinv(vec3D_dbl_ptr_Type& dPhiIn,
                     vec3D_dbl_Type& dPhiOut,
                     SmallMatrix<SC>& Binv);
@@ -282,11 +257,6 @@ class FE {
                                  MatrixPtr_Type &A,
                                  bool callFillComplete = true);
 
-    void assemblyNonlinearLaplace(
-        int dim, std::string FEType, int degree, MultiVectorPtr_Type u_rep,
-        BlockMatrixPtr_Type &A, BlockMultiVectorPtr_Type &resVec,
-        ParameterListPtr_Type params, std::string assembleMode,
-        bool callFillComplete = true, int FELocExternal = -1);
 
     // // Assembling the reaction term of the reaction diffusion equation. Maybe add default function.
 	// void assemblyLinearReactionTerm(int dim,
@@ -542,172 +512,10 @@ class FE {
 
     void epsilonTensor(vec_dbl_Type &basisValues, SmallMatrix<SC> &epsilonValues, int activeDof);
 
-    void assemblyNavierStokes(int dim,
-								std::string FETypeVelocity,
-								std::string FETypePressure,
-								int degree,
-								int dofsVelocity,
-								int dofsPressure,
-								MultiVectorPtr_Type u_rep,
-								MultiVectorPtr_Type p_rep,
-								BlockMatrixPtr_Type &A,
-								BlockMultiVectorPtr_Type &resVec,
-								SmallMatrix_Type coeff,
-								ParameterListPtr_Type params,
-								bool reAssemble,
-							        std::string assembleMode,
-								bool callFillComplete = true,
-								int FELocExternal=-1);
-
-    void assemblyLaplaceAssFE(int dim,
-                            std::string FEType,
-                            int degree,
-                            int dofs,
-                            BlockMatrixPtr_Type &A,
-                            bool callFillComplete,
-                            int FELocExternal=-1);
-
-    void assemblyAceDeformDiffu(int dim,
-								std::string FETypeChem,
-								std::string FETypeSolid,
-								int degree,
-								int dofsChem,
-								int dofsSolid,
-								MultiVectorPtr_Type c_rep,
-								MultiVectorPtr_Type d_rep,
-								BlockMatrixPtr_Type &A,
-								BlockMultiVectorPtr_Type &resVec,
-								ParameterListPtr_Type params,
-							        std::string assembleMode,
-								bool callFillComplete = true,
-								int FELocExternal=-1);
-
-    void assemblyAceDeformDiffuBlock(int dim,
-                                std::string FETypeChem,
-                                std::string FETypeSolid,
-                                int degree,
-                                int dofsChem,
-                                int dofsSolid,
-                                MultiVectorPtr_Type c_rep,
-                                MultiVectorPtr_Type d_rep,
-                                BlockMatrixPtr_Type &A,
-                                int blockRow,
-                                int blockCol,
-                                BlockMultiVectorPtr_Type &resVec,
-                                int block,
-                                ParameterListPtr_Type params,
-                                std::string assembleMode,
-                                bool callFillComplete = true,
-                                int FELocExternal=-1);
-
-    void advanceInTimeAssemblyFEElements(double dt ,MultiVectorPtr_Type d_rep , MultiVectorPtr_Type c_rep) 
-    {
-        //UN FElocChem = 1; //checkFE(dim,FETypeChem); // Checks for different domains which belongs to a certain fetype
-        UN FElocSolid = 0; //checkFE(dim,FETypeSolid); // Checks for different domains which belongs to a certain fetype
-
-        //ElementsPtr_Type elementsChem= domainVec_.at(FElocChem)->getElementsC();
-
-        ElementsPtr_Type elementsSolid = domainVec_.at(FElocSolid)->getElementsC();
-        
-        vec_dbl_Type solution_c;
-	    vec_dbl_Type solution_d;
-        for (UN T=0; T<assemblyFEElements_.size(); T++) {
-		    vec_dbl_Type solution(0);
-
-            solution_c = getSolution(elementsSolid->getElement(T).getVectorNodeList(), c_rep,1);
-            solution_d = getSolution(elementsSolid->getElement(T).getVectorNodeList(), d_rep,3);
-            // First Solid, then Chemistry
-            solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
-            solution.insert( solution.end(), solution_c.begin(), solution_c.end() );
-            
-            assemblyFEElements_[T]->updateSolution(solution);
-
-            assemblyFEElements_[T]->advanceInTime(dt);
-        }
-        
-    }
-
-	void assemblyLinearElasticity(int dim,
-                                std::string FEType,
-                                int degree,
-                                int dofs,
-                                MultiVectorPtr_Type d_rep,
-                                BlockMatrixPtr_Type &A,
-                                BlockMultiVectorPtr_Type &resVec,
-                                ParameterListPtr_Type params,
-                                bool reAssemble,
-                                std::string assembleMode,
-                                bool callFillComplete=true,
-                                int FELocExternal=-1);
-
-    void assemblyNonLinearElasticity(int dim,
-                                    std::string FEType,
-                                    int degree,
-                                    int dofs,
-                                    MultiVectorPtr_Type d_rep,
-                                    BlockMatrixPtr_Type &A,
-                                    BlockMultiVectorPtr_Type &resVec,
-                                    ParameterListPtr_Type params,
-                                    bool callFillComplete=true,
-                                    int FELocExternal=-1);
-                                    
-    void assemblyNonLinearElasticity(int dim,
-                                    std::string FEType,
-                                    int degree,
-                                    int dofs,
-                                    MultiVectorPtr_Type d_rep,
-                                    BlockMatrixPtr_Type &A,
-                                    BlockMultiVectorPtr_Type &resVec,
-                                    ParameterListPtr_Type params, 									
-                                    DomainConstPtr_Type domain,
-                                    MultiVectorPtr_Type eModVec,
-                                    bool callFillComplete = true,
-                                    int FELocExternal=-1);
-                                    
-    void checkMeshOrientation(int dim, std::string FEType);
-
-    /* Given a converged velocity solution this function 
-       computes the averaged viscosity estimate in each cell at the center of mass 
-       - CM stands for center of mass so the values at the node are averaged to obtain one value
-    */
-    void computeSteadyViscosityFE_CM(int dim,
-	                                    std::string FETypeVelocity,
-	                                    std::string FETypePressure,
-										int dofsVelocity,
-										int dofsPressure,
-										MultiVectorPtr_Type u_rep,
-										MultiVectorPtr_Type p_rep,
- 										ParameterListPtr_Type params);
-
-    // Change for all assembleFEElements the linearization type to the specified ones
-    void  changeLinearizationFE(std::string linearization);
-
-    // Write prostprocessing output fields like e.g. the viscosity based on  velocity, pressure .. solution
-    // inside this BMV -> For visualization or postprocessing                                
-    BlockMultiVectorPtr_Type const_output_fields;
-
-
-
+    Teuchos::RCP<ElementSpec> es_;
 
 /* ----------------------------------------------------------------------------------------*/
 private:
-	void addFeBlockMatrix(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement element1,FiniteElement element2, MapConstPtr_Type mapFirstColumn,MapConstPtr_Type mapSecondColumn, tuple_disk_vec_ptr_Type problemDisk);
-
-	void addFeBlock(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement element, MapConstPtr_Type mapFirstRow, int row, int column, tuple_disk_vec_ptr_Type problemDisk);
-
-    void initAssembleFEElements(std::string elementType, tuple_disk_vec_ptr_Type problemDisk, ElementsPtr_Type elements, ParameterListPtr_Type params, vec2D_dbl_ptr_Type pointsRep, MapConstPtr_Type elementMap);
-
-    void addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec, FiniteElement elementBlock1,FiniteElement elementBlock2, int dofs1, int dofs2 );
-
-    void addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec, FiniteElement elementBlock, int dofs);
-		
-    void computeSurfaceNormal(int dim,vec2D_dbl_ptr_Type pointsRep,vec_int_Type nodeList,vec_dbl_Type &v_E, double &norm_v_E);
-
-
-	AssembleFEPtr_vec_Type assemblyFEElements_;
-
-	vec2D_dbl_Type getCoordinates(vec_LO_Type localIDs, vec2D_dbl_ptr_Type points);
-	vec_dbl_Type getSolution(vec_LO_Type localIDs, MultiVectorPtr_Type u_rep, int dofsVelocity);
 
     //Start of AceGen code
     /*! AceGen code for 3D Neo-Hooke material model
@@ -764,77 +572,13 @@ private:
     // void SKR_Biot3D(double* v,ElementSpec *es,ElementData *ed, NodeSpec **ns, NodeData **nd,double *rdata,int *idata,double *p,double **s);
     
     //End of AceGen code
-    
-    void buildTransformation(const vec_int_Type& element,
-                             vec2D_dbl_ptr_Type pointsRep,
-                             SmallMatrix<SC>& B,
-                             std::string FEType="P");
-    
-    void buildTransformation(const vec_int_Type& element,
-                             vec2D_dbl_ptr_Type pointsRep,
-                             SmallMatrix<SC>& B,
-                             vec_dbl_Type& b,
-                             std::string FEType="P");
-
-    
-    void buildTransformationSurface(const vec_int_Type& element,
-                                    vec2D_dbl_ptr_Type pointsRep,
-                                    SmallMatrix<SC>& B,
-                                    vec_dbl_Type& b,
-                                    std::string FEType="P");
 
     void applyDiff(vec3D_dbl_Type& dPhiIn,
                    vec3D_dbl_Type& dPhiOut,
                    SmallMatrix<SC>& diffT);
     
     
-    void phi(       int Dimension,
-                    int intFE,
-            		int i,
-            		vec_dbl_Type &QuadPts,
-            		double* value);
-
-
-    void gradPhi(	int Dimension,
-                    int intFE,
-                    int i,
-                    vec_dbl_Type &QuadPts,
-                    vec_dbl_ptr_Type &value);
-    
-    /*! Most of the quadrature formulas can be found in http://code-aster.org/doc/v11/en/man_r/r3/r3.01.01.pdf 01/2021  */
-    void getQuadratureValues(int Dimension,
-                            int Degree,
-                            vec2D_dbl_ptr_Type &QuadPts,
-                            vec_dbl_ptr_Type &QuadW,
-                            std::string FEType);
-    
-    int getPhi(	vec2D_dbl_ptr_Type &Phi,
-                vec_dbl_ptr_Type &weightsPhi,
-                int Dimension,
-                std::string FEType,
-                int Degree,
-                std::string FETypeQuadPoints="");
-
-    int getPhiGlobal(vec2D_dbl_ptr_Type &Phi,
-                     vec_dbl_ptr_Type &weightsPhi,
-                     int Dimension,
-                     std::string FEType,
-                     int Degree);
-
-    int getDPhi(	vec3D_dbl_ptr_Type &DPhi,
-                	vec_dbl_ptr_Type &weightsDPhi,
-                    int Dimension,
-                    std::string FEType,
-                    int Degree);
-
-    int checkFE(int Dimension,
-                std::string FEType);
-    
-
-    bool setZeros_;
-    SC myeps_;
     std::vector<Teuchos::RCP<DataElement> > ed_;
-    bool saveAssembly_;
 };
 }
 #endif

--- a/feddlib/core/FE/FE_def.hpp
+++ b/feddlib/core/FE/FE_def.hpp
@@ -57,36 +57,16 @@ void DataElement::setHp( double* ht )
         hp_[i] = ht[i];
 }
 
-
+/*!
+ \brief Constructor of FE calling the constructor of FE_ElementAssembly accordingly 
+*/
 template <class SC, class LO, class GO, class NO>
-FE<SC,LO,GO,NO>::FE(bool saveAssembly):
-domainVec_(0),
-es_(),
-setZeros_(false),
-myeps_(),
-ed_(0),
-saveAssembly_(saveAssembly)
+FE<SC,LO,GO,NO>::FE(bool saveAssembly):FE_ElementAssembly<SC, LO, GO, NO>(saveAssembly),
+ed_(0), 
+es_()
 {
 }
 
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::addFE(DomainConstPtr_Type domain){
-    
-    if (saveAssembly_){
-        DomainPtr_Type domainNC = Teuchos::rcp_const_cast<Domain_Type>( domain );
-        domainNC->initializeFEData();
-    }
-    domainVec_.push_back(domain);
-
-}
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::doSetZeros(double eps){
-
-    setZeros_ = true;
-    myeps_ = eps;
-
-}
 
 template <class SC, class LO, class GO, class NO>
 void FE<SC,LO,GO,NO>::applyBTinv( vec3D_dbl_ptr_Type& dPhiIn,
@@ -102,1368 +82,6 @@ void FE<SC,LO,GO,NO>::applyBTinv( vec3D_dbl_ptr_Type& dPhiIn,
             }
         }
     }
-}
-
-/*!
-
- \brief Assembly of Jacobian 
-@param[in] dim Dimension
-@param[in] FEType FE Discretization
-@param[in] degree Degree of basis function
-@param[in] A Resulting matrix
-@param[in] callFillComplete If Matrix A should be completely filled at end of function
-@param[in] FELocExternal 
-
-*/
-
-// Check the order of chemistry and solid in system matrix
-/*template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::globalAssembly(std::string ProblemType,
-                        int dim,                    
-                        int degree,                       
-                        MultiVectorPtr_Type sol_rep,
-                        BlockMatrixPtr_Type &A,
-                        BlockMultiVectorPtr_Type &resVec,
-                        ParameterListPtr_Type params,
-                        std::string assembleMode,
-                        bool callFillComplete,
-                        int FELocExternal){
-
-    int problemSize = domainVec_.size(); // Problem size, as in number of subproblems
-
-    // Depending on problem size we extract necessary information 
-
-	/// Tupel construction follows follwing pattern:
-	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
-	int numChem=3;
-    if(FETypeChem == "P2"){
-        numChem=6;
-    }    
-	if(dim==3){
-		numChem=4;
-        if(FETypeChem == "P2")
-            numChem=10;
-	}
-    int numSolid=3;
-    if(FETypeSolid == "P2")
-        numSolid=6;
-        
-	if(dim==3){
-		numSolid=4;
-        if(FETypeSolid == "P2")
-            numSolid=10;
-	}
-
-	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 2) );
-
-	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
-    for(int i=0; i< problemSize; i++){
-        int numNodes=0.;
-        if(domainVec.at(i)->getFEType() == "P2"){
-            numNodes=6;
-        }    
-        if(dim==3){
-            numNodes=4;
-            if(domainVec.at(i)->getFEType() == "P2")
-                numNodes=10;
-        }
-        tuple_ssii_Type infoTuple (domainVec.at(i)->getPhysic(),domainVec.at(i)->getFEType(),domainVec.at(i)->getDofs(),numChem);
-        problemDisk->push_back(infoTuple);
-
-        MultiVectorPtr_Type resVec;
-        if(domainVec.at(i)->getDofs() == 1)
-            resVec = Teuchos::rcp( new MultiVector_Type( domainVec_.at(i)->getMapRepeated(), 1 ) );
-        else
-            resVec = Teuchos::rcp( new MultiVector_Type( domainVec_.at(i)->getMapVecFieldRepeated(), 1 ) );
-
-        resVecRep->addBlock(resVec,i);
-
-
-    }
-	
-
-	if(assemblyFEElements_.size()== 0){
-       	initAssembleFEElements(ProblemType,problemDisk,domainVec_.at(0)->getElementsC(), params,domainVec_.at(0)->getPointsRepeated(),domainVec_.at(0)->getElementMap());
-    }
-	else if(assemblyFEElements_.size() != domainVec_.at(0)->getElementsC()->numberElements())
-	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
-
-    vec_dbl_Type solution_tmp;
-    for (UN T=0; T<assemblyFEElements_.size(); T++) {
-		vec_dbl_Type solution(0);
-        vec_FE_Type elements;
-        for(int i=0; i< problemSize; i++){
-		    solution_tmp = getSolution(domainVec_.at(i)->getElementsC()->getElement(T).getVectorNodeList(), sol_rep->getBlock(i),domainVec.at(i)->getDofs());      
-            solution.insert( solution.end(), solution_tmp.begin(), solution_tmp.end() );
-
-
-        }   
-        
-  		assemblyFEElements_[T]->updateSolution(solution);
-
- 		SmallMatrixPtr_Type elementMatrix;
-	    vec_dbl_ptr_Type rhsVec;
-
-     	if(assembleMode == "Jacobian"){
-			assemblyFEElements_[T]->assembleJacobian();
-
-            elementMatrix = assemblyFEElements_[T]->getJacobian(); 
-            //elementMatrix->print();
-			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
-			
-			addFeBlockMatrix(A, elementMatrix, domainVec_.at(0)->getElementsC()->getElement(T), problemDisk);
-    
-		}
-		if(assembleMode == "Rhs"){
-		    assemblyFEElements_[T]->assembleRHS();
-		    rhsVec = assemblyFEElements_[T]->getRHS(); 
-			addFeBlockMv(resVecRep, rhsVec, elementsSolid->getElement(T),elementsChem->getElement(T), dofsSolid,dofsChem);
-
-		}
-      		
-	}
-	if ( assembleMode == "Jacobian"){
-        for(int probRow = 0; probRow <  problemSize; probRow++){
-            for(int probCol = 0; probCol <  problemSize; probCol++){
-                MapConstPtr_Type rowMap;
-                MapConstPtr_Type domainMap;
-
-                if(domainVec.at(probRow)->getDofs() == 1)
-                    rowMap = domainVec_.at(FElocRow)->getMapUnique();
-                else
-                    rowMap = domainVec_.at(probRow)->getMapVecFieldUnique();
-
-                if(domainVec.at(probCol)->getDofs() == 1)
-                    domainMap = domainVec_.at(probCol)->getMapUnique()
-                else
-                    domainMap = domainVec_.at(probCol)->getMapVecFieldUnique()
-
-                A->getBlock(probRow,probCol)->fillComplete(domainMap,rowMap);
-            }
-        }
-	}
-    else if(assembleMode == "Rhs"){
-
-        for(int probRow = 0; probRow <  problemSize; probRow++){
-            MapConstPtr_Type rowMap;
-             if(domainVec.at(probRow)->getDofs() == 1)
-                rowMap = domainVec_.at(FElocRow)->getMapUnique();
-            else
-                rowMap = domainVec_.at(probRow)->getMapVecFieldUnique();
-
-		    MultiVectorPtr_Type resVecUnique = Teuchos::rcp( new MultiVector_Type( rowMap, 1 ) );
-
-            resVecUnique->putScalar(0.);
-
-            resVecUnique->exportFromVector( resVecRep, true, "Add" );
-
-            resVec->addBlock(resVecUnique,probRow);
-        }
-	}
-
-}*/
-
-/*!
-
- \brief Inserting element stiffness matrices into global stiffness matrix
-
-
-@param[in] &A Global Block Matrix
-@param[in] elementMatrix Stiffness matrix of one element
-@param[in] element Corresponding finite element
-@param[in] map Map that corresponds to repeated nodes of first block
-@param[in] map Map that corresponds to repeated nodes of second block
-
-*/
-/*template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::addFeBlockMatrix(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement_vec element, tuple_disk_vec_ptr_Type problemDisk){
-		
-    int numDisk = problemDisk->size();
-
-    for(int probRow = 0; probRow < numDisk; probRow++){
-        for(int probCol = 0; probCol < numDisk; probCol++){
-            int dofs1 = std::get<2>(problemDisk->at(probRow));
-            int dofs2 = std::get<2>(problemDisk->at(probCol));
-
-            int numNodes1 = std::get<3>(problemDisk->at(probRow));
-            int numNodes2=std::get<3>(problemDisk->at(probCol));
-
-            int offsetRow= numNodes1*dofs1*probRow;
-            int offsetCol= numNodes1*dofs1*probCol;
-
-            mapRow = domainVec.at(probRow)->getMapRepeated();
-            mapCol = domainVec.at(probCol)->getMapRepeated();
-
-            Teuchos::Array<SC> value2( numNodes2, 0. );
-            Teuchos::Array<GO> columnIndices2( numNodes2, 0 );
-            for (UN i=0; i < numNodes1; i++){
-                for(int di=0; di<dofs1; di++){				
-                    GO row =GO (dofs1* mapRow->getGlobalElement( element[probRow].getNode(i) )+di);
-                    for(int d=0; d<dofs2; d++){				
-                        for (UN j=0; j < numNodes2 ; j++) {
-                            value2[j] = (*elementMatrix)[offsetRow+i*dofs1+di][offsetCol+j*dofs2+d];			    				    		
-                            columnIndices2[j] =GO (dofs2* mapCol->getGlobalElement( element.getNode(j) )+d);
-                        }
-                        A->getBlock(probRow,probCol)->insertGlobalValues( row, columnIndices2(), value2() ); // Automatically adds entries if a value already exists                            
-                    }
-                }      
-            }
-
-        }
-    }
-}
-
-*/
-
-/*!
-
- \brief Inserting local rhsVec into global residual Mv;
-
-
-@param[in] res BlockMultiVector of residual vec; Repeated distribution; 2 blocks
-@param[in] rhsVec sorted the same way as residual vec
-@param[in] element of block1
-
-*/
-/*
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec,tuple_disk_vec_ptr_Type problemDisk, FiniteElement_vec element)
-    int numDisk = problemDisk->size();
-
-    for(int probRow = 0; probRow < numDisk; probRow++){
-        Teuchos::ArrayRCP<SC>  resArray_block = res->getBlockNonConst(probRow)->getDataNonConst(0);
-      	vec_LO_Type nodeList_block = element[probRow].getVectorNodeList();
-        int dofs = std::get<2>(problemDisk->at(probRow));
-        int numNodes = std::get<3>(problemDisk->at(probRow));
-
-        int offset = numNodes*dofs; 
-        for(int i=0; i< nodeList_block.size() ; i++){
-            for(int d=0; d<dofs; d++){
-                resArray_block[nodeList_block[i]*dofs+d] += (*rhsVec)[i*dofs+d+offset];
-            }
-        }
-    }
-}
-*/
-
-/*!
-
- \brief Assembly of Jacobian for Linear Elasticity
-@param[in] dim Dimension
-@param[in] FEType FE Discretization
-@param[in] degree Degree of basis function
-@param[in] A Resulting matrix
-@param[in] callFillComplete If Matrix A should be completely filled at end of function
-@param[in] FELocExternal 
-
-*/
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::assemblyLinearElasticity(int dim,
-	                                    std::string FEType,
-	                                    int degree,
-										int dofs,
-										MultiVectorPtr_Type d_rep,
-	                                    BlockMatrixPtr_Type &A,
-										BlockMultiVectorPtr_Type &resVec,
- 										ParameterListPtr_Type params,
- 										bool reAssemble,
- 										std::string assembleMode,
-	                                    bool callFillComplete,
-	                                    int FELocExternal){
-	
-	ElementsPtr_Type elements = domainVec_.at(0)->getElementsC();
-
-	int dofsElement = elements->getElement(0).getVectorNodeList().size();
-
-	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(0)->getPointsRepeated();
-
-	MapConstPtr_Type mapVel = domainVec_.at(0)->getMapRepeated();
-
-	vec_dbl_Type solution(0);
-	vec_dbl_Type solution_d;
-
-	vec_dbl_Type rhsVec;
-
-	/// Tupel construction follows follwing pattern:
-	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
-	int numNodes=6;
-	if(dim==3){
-		numNodes=10;
-	}
-	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
-	tuple_ssii_Type displacement ("Displacement",FEType,dofs,numNodes);
-	problemDisk->push_back(displacement);
-
-	if(assemblyFEElements_.size()== 0)
-	 	initAssembleFEElements("LinearElasticity",problemDisk,elements, params,pointsRep,domainVec_.at(0)->getElementMap());
-	else if(assemblyFEElements_.size() != elements->numberElements())
-	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
-
-	MultiVectorPtr_Type resVec_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(0)->getMapVecFieldRepeated(), 1 ) );
-	
-	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 1) );
-	resVecRep->addBlock(resVec_d,0);
-
- 	SmallMatrixPtr_Type elementMatrix;
-	for (UN T=0; T<assemblyFEElements_.size(); T++) {
-		vec_dbl_Type solution(0);
-
-		solution_d = getSolution(elements->getElement(T).getVectorNodeList(), d_rep,dofs);
-
-		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
-
-		assemblyFEElements_[T]->updateSolution(solution);
- 
-		assemblyFEElements_[T]->assembleJacobian();
-
-		elementMatrix = assemblyFEElements_[T]->getJacobian(); 
-			
-		assemblyFEElements_[T]->advanceNewtonStep();
-
-
-		addFeBlock(A, elementMatrix, elements->getElement(T), mapVel, 0, 0, problemDisk);
-			
-	}
-	if (callFillComplete)
-	    A->getBlock(0,0)->fillComplete( domainVec_.at(0)->getMapVecFieldUnique(),domainVec_.at(0)->getMapVecFieldUnique());
-	
-
-
-
-}
-
-/*!
-
- \brief Assembly of Jacobian for nonlinear Elasticity
-@param[in] dim Dimension
-@param[in] FEType FE Discretization
-@param[in] degree Degree of basis function
-@param[in] A Resulting matrix
-@param[in] callFillComplete If Matrix A should be completely filled at end of function
-@param[in] FELocExternal 
-
-*/
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::assemblyNonLinearElasticity(int dim,
-	                                    std::string FEType,
-	                                    int degree,
-										int dofs,
-										MultiVectorPtr_Type d_rep,
-	                                    BlockMatrixPtr_Type &A,
-										BlockMultiVectorPtr_Type &resVec,
- 										ParameterListPtr_Type params, 									
-	                                    bool callFillComplete,
-	                                    int FELocExternal){
-	
-	ElementsPtr_Type elements = domainVec_.at(0)->getElementsC();
-
-	int dofsElement = elements->getElement(0).getVectorNodeList().size();
-
-	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(0)->getPointsRepeated();
-
-	MapConstPtr_Type map = domainVec_.at(0)->getMapRepeated();
-
-	vec_dbl_Type solution(0);
-	vec_dbl_Type solution_d;
-
-	vec_dbl_ptr_Type rhsVec;
-
-	/// Tupel construction follows follwing pattern:
-	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
-	int numNodes=6;
-	if(dim==3){
-		numNodes=10;
-	}
-	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
-	tuple_ssii_Type displacement ("Displacement",FEType,dofs,numNodes);
-	problemDisk->push_back(displacement);
-
-    int neoHookeNum = params->sublist("Parameter").get("Neo-Hooke Modell",1);
-
-    std::string nonLinElasModell = "NonLinearElasticity2";
-    if(neoHookeNum == 1)
-        nonLinElasModell = "NonLinearElasticity";
-
-    //std::cout << " ######## Assembly Modell: " << nonLinElasModell << " ############ " <<  std::endl;
-
-
-	if(assemblyFEElements_.size()== 0)
-	 	initAssembleFEElements(nonLinElasModell,problemDisk,elements, params,pointsRep,domainVec_.at(0)->getElementMap());
-	else if(assemblyFEElements_.size() != elements->numberElements())
-	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
-	
-
- 	SmallMatrixPtr_Type elementMatrix;
-	for (UN T=0; T<assemblyFEElements_.size(); T++) {
-		vec_dbl_Type solution(0);
-
-		solution_d = getSolution(elements->getElement(T).getVectorNodeList(), d_rep,dofs);
-
-		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
-
-		assemblyFEElements_[T]->updateSolution(solution);
-
-        assemblyFEElements_[T]->assembleJacobian();
-        elementMatrix = assemblyFEElements_[T]->getJacobian();              
-        addFeBlock(A, elementMatrix, elements->getElement(T), map, 0, 0, problemDisk);
-
-        assemblyFEElements_[T]->assembleRHS();
-        rhsVec = assemblyFEElements_[T]->getRHS(); 
-        addFeBlockMv(resVec, rhsVec, elements->getElement(T),  dofs);
-
-        assemblyFEElements_[T]->advanceNewtonStep();
-
-
-	}
-	if (callFillComplete)
-	    A->getBlock(0,0)->fillComplete( domainVec_.at(0)->getMapVecFieldUnique(),domainVec_.at(0)->getMapVecFieldUnique());
-	
-}
-
-/*!
-
- \brief Assembly of Jacobian for nonlinear Elasticity
-@param[in] dim Dimension
-@param[in] FEType FE Discretization
-@param[in] degree Degree of basis function
-@param[in] A Resulting matrix
-@param[in] callFillComplete If Matrix A should be completely filled at end of function
-@param[in] FELocExternal 
-
-*/				
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::assemblyNonLinearElasticity(int dim,
-	                                    std::string FEType,
-	                                    int degree,
-										int dofs,
-										MultiVectorPtr_Type d_rep,
-	                                    BlockMatrixPtr_Type &A,
-										BlockMultiVectorPtr_Type &resVec,
- 										ParameterListPtr_Type params, 									
-                                        DomainConstPtr_Type domain,
-                                        MultiVectorPtr_Type eModVec,
-	                                    bool callFillComplete,
-	                                    int FELocExternal){
-	
-	ElementsPtr_Type elements = domain->getElementsC();
-
-	int dofsElement = elements->getElement(0).getVectorNodeList().size();
-
-	vec2D_dbl_ptr_Type pointsRep = domain->getPointsRepeated();
-
-	MapConstPtr_Type map = domain->getMapRepeated();
-
-	vec_dbl_Type solution(0);
-	vec_dbl_Type solution_d;
-
-	vec_dbl_ptr_Type rhsVec;
-
-	/// Tupel construction follows follwing pattern:
-	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
-	int numNodes=6;
-	if(dim==3){
-		numNodes=10;
-	}
-	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
-	tuple_ssii_Type displacement ("Displacement",FEType,dofs,numNodes);
-	problemDisk->push_back(displacement);
-
-    int neoHookeNum = params->sublist("Parameter").get("Neo-Hooke Modell",1);
-
-    std::string nonLinElasModell = "NonLinearElasticity2";
-    if(neoHookeNum == 1)
-        nonLinElasModell = "NonLinearElasticity";
-
-    //std::cout << " ######## Assembly Modell: " << nonLinElasModell << " ############ " <<  std::endl;
-
-	if(assemblyFEElements_.size()== 0)
-	 	initAssembleFEElements(nonLinElasModell,problemDisk,elements, params,pointsRep,domain->getElementMap());
-	else if(assemblyFEElements_.size() != elements->numberElements())
-	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
-	
-    Teuchos::ArrayRCP<SC>  eModVecA = eModVec->getDataNonConst(0);
-
- 	SmallMatrixPtr_Type elementMatrix;
-	for (UN T=0; T<assemblyFEElements_.size(); T++) {
-		vec_dbl_Type solution(0);
-
-		solution_d = getSolution(elements->getElement(T).getVectorNodeList(), d_rep,dofs);
-
-		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
-
-		assemblyFEElements_[T]->updateSolution(solution);
-        assemblyFEElements_[T]->updateParameter("E",eModVecA[T]);
-        assemblyFEElements_[T]->assembleJacobian();
-        elementMatrix = assemblyFEElements_[T]->getJacobian();              
-        addFeBlock(A, elementMatrix, elements->getElement(T), map, 0, 0, problemDisk);
-
-        assemblyFEElements_[T]->assembleRHS();
-        rhsVec = assemblyFEElements_[T]->getRHS(); 
-        addFeBlockMv(resVec, rhsVec, elements->getElement(T),  dofs);
-
-        assemblyFEElements_[T]->advanceNewtonStep();
-
-
-	}
-	if (callFillComplete)
-	    A->getBlock(0,0)->fillComplete( domainVec_.at(0)->getMapVecFieldUnique(),domainVec_.at(0)->getMapVecFieldUnique());
-	
-}
-
-
-
-/*!
-
- \brief Inserting local rhsVec into global residual Mv;
-
-
-@param[in] res BlockMultiVector of residual vec; Repeated distribution; 2 blocks
-@param[in] rhsVec sorted the same way as residual vec
-@param[in] element of block1
-
-*/
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec, FiniteElement elementBlock, int dofs){
-
-    Teuchos::ArrayRCP<SC>  resArray_block = res->getBlockNonConst(0)->getDataNonConst(0);
-
-	vec_LO_Type nodeList_block = elementBlock.getVectorNodeList();
-
-	for(int i=0; i< nodeList_block.size() ; i++){
-		for(int d=0; d<dofs; d++)
-			resArray_block[nodeList_block[i]*dofs+d] += (*rhsVec)[i*dofs+d];
-	}
-}
-
-// Check the order of chemistry and solid in system matrix
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::assemblyAceDeformDiffu(int dim,
-                        std::string FETypeChem,
-                        std::string FETypeSolid,
-                        int degree,
-                        int dofsChem,
-                        int dofsSolid,
-                        MultiVectorPtr_Type c_rep,
-                        MultiVectorPtr_Type d_rep,
-                        BlockMatrixPtr_Type &A,
-                        BlockMultiVectorPtr_Type &resVec,
-                        ParameterListPtr_Type params,
-                        std::string assembleMode,
-                        bool callFillComplete,
-                        int FELocExternal){
-
-    if((FETypeChem != "P2") || (FETypeSolid != "P2") || dim != 3)
-    	TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "No AceGen Implementation available for Discretization and Dimension." );
-
-
-    UN FElocChem = 1; //checkFE(dim,FETypeChem); // Checks for different domains which belongs to a certain fetype
-    UN FElocSolid = 0; //checkFE(dim,FETypeSolid); // Checks for different domains which belongs to a certain fetype
-
-	ElementsPtr_Type elementsChem= domainVec_.at(FElocChem)->getElementsC();
-
-	ElementsPtr_Type elementsSolid = domainVec_.at(FElocSolid)->getElementsC();
-
-    //this->domainVec_.at(FElocChem)->info();
-    //this->domainVec_.at(FElocSolid)->info();
-	//int dofsElement = elements->getElement(0).getVectorNodeList().size();
-
-	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FElocSolid)->getPointsRepeated();
-
-	MapConstPtr_Type mapChem = domainVec_.at(FElocChem)->getMapRepeated();
-
-	MapConstPtr_Type mapSolid = domainVec_.at(FElocSolid)->getMapRepeated();
-
-	vec_dbl_Type solution_c;
-	vec_dbl_Type solution_d;
-
-	vec_dbl_ptr_Type rhsVec;
-
-	/// Tupel construction follows follwing pattern:
-	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
-	int numChem=3;
-    if(FETypeChem == "P2"){
-        numChem=6;
-    }    
-	if(dim==3){
-		numChem=4;
-        if(FETypeChem == "P2")
-            numChem=10;
-	}
-    int numSolid=3;
-    if(FETypeSolid == "P2")
-        numSolid=6;
-        
-	if(dim==3){
-		numSolid=4;
-        if(FETypeSolid == "P2")
-            numSolid=10;
-	}
-	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
-	tuple_ssii_Type chem ("Chemistry",FETypeChem,dofsChem,numChem);
-	tuple_ssii_Type solid ("Solid",FETypeSolid,dofsSolid,numSolid);
-	problemDisk->push_back(solid);
-	problemDisk->push_back(chem);
-
-	tuple_disk_vec_ptr_Type problemDiskChem = Teuchos::rcp(new tuple_disk_vec_Type(0));
-    problemDiskChem->push_back(chem);
-
-	std::string SCIModel = params->sublist("Parameter").get("Structure Model","SCI_simple");
-
-	if(assemblyFEElements_.size()== 0){
-       	initAssembleFEElements(SCIModel,problemDisk,elementsChem, params,pointsRep,domainVec_.at(FElocSolid)->getElementMap());
-    }
-	else if(assemblyFEElements_.size() != elementsChem->numberElements())
-	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
-
-	//SmallMatrixPtr_Type elementMatrix =Teuchos::rcp( new SmallMatrix_Type( dofsElement));
-
-	MultiVectorPtr_Type resVec_c = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocChem)->getMapRepeated(), 1 ) );
-    MultiVectorPtr_Type resVec_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocSolid)->getMapVecFieldRepeated(), 1 ) );
-	
-	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 2) );
-    resVecRep->addBlock(resVec_d,0);
-    resVecRep->addBlock(resVec_c,1);
-   
-    SC detB;
-    SC absDetB;
-    SmallMatrix<SC> B(dim);
-    SmallMatrix<SC> Binv(dim);
-
-
-    for (UN T=0; T<assemblyFEElements_.size(); T++) {
-		vec_dbl_Type solution(0);
-
-		solution_c = getSolution(elementsChem->getElement(T).getVectorNodeList(), c_rep,dofsChem);
-		solution_d = getSolution(elementsSolid->getElement(T).getVectorNodeList(), d_rep,dofsSolid);
-
-        // First Solid, then Chemistry
-		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
-		solution.insert( solution.end(), solution_c.begin(), solution_c.end() );
-        
-  		assemblyFEElements_[T]->updateSolution(solution);
-
- 		SmallMatrixPtr_Type elementMatrix;
-
-        // ------------------------
-        /*buildTransformation(elementsSolid->getElement(T).getVectorNodeList(), pointsRep, B, FETypeSolid);
-        detB = B.computeInverse(Binv);
-        absDetB = std::fabs(detB);
-        std::cout << " Determinante " << detB << std::endl;*/
-        // ------------------------
-
-
-
-
-		if(assembleMode == "Jacobian"){
-			assemblyFEElements_[T]->assembleJacobian();
-
-            elementMatrix = assemblyFEElements_[T]->getJacobian(); 
-           // elementMatrix->print();
-			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
-			
-			addFeBlockMatrix(A, elementMatrix, elementsSolid->getElement(T), elementsSolid->getElement(T), mapSolid, mapChem, problemDisk);
-
-          
-
-		}
-		if(assembleMode == "Rhs"){
-		    assemblyFEElements_[T]->assembleRHS();
-		    rhsVec = assemblyFEElements_[T]->getRHS(); 
-			addFeBlockMv(resVecRep, rhsVec, elementsSolid->getElement(T),elementsChem->getElement(T), dofsSolid,dofsChem);
-
-		}
-        if(assembleMode=="MassMatrix"){
-            assemblyFEElements_[T]->assembleJacobian();
-
-            AssembleFE_SCI_SMC_Active_Growth_Reorientation_Ptr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFE_SCI_SMC_Active_Growth_Reorientation_Type>(assemblyFEElements_[T] );
-            elTmp->getMassMatrix(elementMatrix);
-            //elementMatrix->print();
-   			addFeBlock(A, elementMatrix, elementsChem->getElement(T), mapChem, 0, 0, problemDiskChem);
-
-
-        }
-
-        
-
-			
-	}
-	if ( assembleMode == "Jacobian"){
-		A->getBlock(0,0)->fillComplete();
-	    A->getBlock(1,0)->fillComplete(domainVec_.at(FElocSolid)->getMapVecFieldUnique(),domainVec_.at(FElocChem)->getMapUnique());
-	    A->getBlock(0,1)->fillComplete(domainVec_.at(FElocChem)->getMapUnique(),domainVec_.at(FElocSolid)->getMapVecFieldUnique());
-	    A->getBlock(1,1)->fillComplete();
-	}
-    else if(assembleMode == "Rhs"){
-
-		MultiVectorPtr_Type resVecUnique_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocSolid)->getMapVecFieldUnique(), 1 ) );
-		MultiVectorPtr_Type resVecUnique_c = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocChem)->getMapUnique(), 1 ) );
-
-		resVecUnique_d->putScalar(0.);
-		resVecUnique_c->putScalar(0.);
-
-		resVecUnique_d->exportFromVector( resVec_d, true, "Add" );
-		resVecUnique_c->exportFromVector( resVec_c, true, "Add" );
-
-		resVec->addBlock(resVecUnique_d,0);
-		resVec->addBlock(resVecUnique_c,1);
-	}
-    else if(assembleMode == "MassMatrix"){
-   		A->getBlock(0,0)->fillComplete();
-    }
-
-}
-
-// Check the order of chemistry and solid in system matrix
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::assemblyAceDeformDiffuBlock(int dim,
-                        std::string FETypeChem,
-                        std::string FETypeSolid,
-                        int degree,
-                        int dofsChem,
-                        int dofsSolid,
-                        MultiVectorPtr_Type c_rep,
-                        MultiVectorPtr_Type d_rep,
-                        BlockMatrixPtr_Type &A,
-                        int blockRow,
-                        int blockCol,
-                        BlockMultiVectorPtr_Type &resVec,
-                        int block,
-                        ParameterListPtr_Type params,
-                        std::string assembleMode,
-                        bool callFillComplete,
-                        int FELocExternal){
-
-    if((FETypeChem != "P2") || (FETypeSolid != "P2") || dim != 3)
-    	TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "No AceGen Implementation available for Discretization and Dimension." );
-    if((blockRow != blockCol) && blockRow != 0)
-        TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Block assemblyDeformDiffu AceGEN Version only implemented for 0,0 block right now" );
-
-    //UN FElocChem = 1; //checkFE(dim,FETypeChem); // Checks for different domains which belongs to a certain fetype
-    UN FElocSolid = 0; //checkFE(dim,FETypeSolid); // Checks for different domains which belongs to a certain fetype
-
-	ElementsPtr_Type elementsChem= domainVec_.at(FElocSolid)->getElementsC();
-
-	ElementsPtr_Type elementsSolid = domainVec_.at(FElocSolid)->getElementsC();
-
-    //this->domainVec_.at(FElocChem)->info();
-    //this->domainVec_.at(FElocSolid)->info();
-	//int dofsElement = elements->getElement(0).getVectorNodeList().size();
-
-	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FElocSolid)->getPointsRepeated();
-
-	//MapConstPtr_Type mapChem = domainVec_.at(FElocChem)->getMapRepeated();
-
-	MapConstPtr_Type mapSolid = domainVec_.at(FElocSolid)->getMapRepeated();
-
-	vec_dbl_Type solution_c;
-	vec_dbl_Type solution_d;
-
-	vec_dbl_ptr_Type rhsVec;
-
-	/// Tupel construction follows follwing pattern:
-	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
-	int numChem=3;
-    if(FETypeChem == "P2"){
-        numChem=6;
-    }    
-	if(dim==3){
-		numChem=4;
-        if(FETypeChem == "P2")
-            numChem=10;
-	}
-    int numSolid=3;
-    if(FETypeSolid == "P2")
-        numSolid=6;
-        
-	if(dim==3){
-		numSolid=4;
-        if(FETypeSolid == "P2")
-            numSolid=10;
-	}
-	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
-	tuple_ssii_Type chem ("Chemistry",FETypeChem,dofsChem,numChem);
-	tuple_ssii_Type solid ("Solid",FETypeSolid,dofsSolid,numSolid);
-	problemDisk->push_back(solid);
-	problemDisk->push_back(chem);
-	
-	std::string SCIModel = params->sublist("Parameter").get("Structure Model","SCI_simple");
-
-	if(assemblyFEElements_.size()== 0){
-       	initAssembleFEElements(SCIModel,problemDisk,elementsChem, params,pointsRep,domainVec_.at(FElocSolid)->getElementMap());
-    }
-	else if(assemblyFEElements_.size() != elementsChem->numberElements())
-	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
-
-	//SmallMatrixPtr_Type elementMatrix =Teuchos::rcp( new SmallMatrix_Type( dofsElement));
-
-	//MultiVectorPtr_Type resVec_c = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocChem)->getMapRepeated(), 1 ) );
-    MultiVectorPtr_Type resVec_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocSolid)->getMapVecFieldRepeated(), 1 ) );
-	
-	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 1) );
-    resVecRep->addBlock(resVec_d,0);
-    //resVecRep->addBlock(resVec_c,1);
-
-    for (UN T=0; T<assemblyFEElements_.size(); T++) {
-		vec_dbl_Type solution(0);
-
-		solution_c = getSolution(elementsChem->getElement(T).getVectorNodeList(), c_rep,dofsChem);
-		solution_d = getSolution(elementsSolid->getElement(T).getVectorNodeList(), d_rep,dofsSolid);
-
-        // First Solid, then Chemistry
-		solution.insert( solution.end(), solution_d.begin(), solution_d.end() );
-		solution.insert( solution.end(), solution_c.begin(), solution_c.end() );
-        
-  		assemblyFEElements_[T]->updateSolution(solution);
-
- 		SmallMatrixPtr_Type elementMatrix;
-
-		if(assembleMode == "Jacobian"){
-			assemblyFEElements_[T]->assembleJacobian();
-
-            elementMatrix = assemblyFEElements_[T]->getJacobian(); 
-           // elementMatrix->print();
-			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
-			addFeBlock(A, elementMatrix, elementsSolid->getElement(T), mapSolid, 0, 0, problemDisk);
-			//addFeBlockMatrix(A, elementMatrix, elementsSolid->getElement(T),  mapSolid, mapChem, problemDisk);
-		}
-		if(assembleMode == "Rhs"){
-		    assemblyFEElements_[T]->assembleRHS();
-		    rhsVec = assemblyFEElements_[T]->getRHS(); 
-			addFeBlockMv(resVecRep, rhsVec, elementsSolid->getElement(T), dofsSolid);
-		}
-        //if(assembleMode=="compute")
-        //    assemblyFEElements_[T]->compute();
-
-        
-
-			
-	}
-	if ( assembleMode != "Rhs"){
-		A->getBlock(0,0)->fillComplete();
-	    //A->getBlock(1,0)->fillComplete(domainVec_.at(FElocSolid)->getMapVecFieldUnique(),domainVec_.at(FElocChem)->getMapUnique());
-	    //A->getBlock(0,1)->fillComplete(domainVec_.at(FElocChem)->getMapUnique(),domainVec_.at(FElocSolid)->getMapVecFieldUnique());
-	    //A->getBlock(1,1)->fillComplete();
-	}
-
-    if(assembleMode == "Rhs"){
-
-		MultiVectorPtr_Type resVecUnique_d = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocSolid)->getMapVecFieldUnique(), 1 ) );
-		//MultiVectorPtr_Type resVecUnique_c = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocChem)->getMapUnique(), 1 ) );
-
-		resVecUnique_d->putScalar(0.);
-		//resVecUnique_c->putScalar(0.);
-
-		resVecUnique_d->exportFromVector( resVec_d, true, "Add" );
-		//resVecUnique_c->exportFromVector( resVec_c, true, "Add" );
-
-		resVec->addBlock(resVecUnique_d,0);
-		//resVec->addBlock(resVecUnique_c,1);
-	}
-
-
-}
-/*!
-
- \brief Inserting element stiffness matrices into global stiffness matrix
-
-
-@param[in] &A Global Block Matrix
-@param[in] elementMatrix Stiffness matrix of one element
-@param[in] element Corresponding finite element
-@param[in] map Map that corresponds to repeated nodes of first block
-@param[in] map Map that corresponds to repeated nodes of second block
-
-*/
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::addFeBlockMatrix(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement element1, FiniteElement element2, MapConstPtr_Type mapFirstRow,MapConstPtr_Type mapSecondRow, tuple_disk_vec_ptr_Type problemDisk){
-		
-		int numDisk = problemDisk->size();
-
-		int dofs1 = std::get<2>(problemDisk->at(0));
-		int dofs2 = std::get<2>(problemDisk->at(1));
-
-		int numNodes1 = std::get<3>(problemDisk->at(0));
-		int numNodes2=std::get<3>(problemDisk->at(1));
-
-		int dofsBlock1 = dofs1*numNodes1;
-		int dofsBlock2  = dofs2*numNodes2;
-
-		Teuchos::Array<SC> value1( numNodes1, 0. );
-        Teuchos::Array<GO> columnIndices1( numNodes1, 0 );
-
-        Teuchos::Array<SC> value2( numNodes2, 0. );
-        Teuchos::Array<GO> columnIndices2( numNodes2, 0 );
-
-		for (UN i=0; i < numNodes1 ; i++) {
-			for(int di=0; di<dofs1; di++){
-				GO row =GO (dofs1* mapFirstRow->getGlobalElement( element1.getNode(i) )+di);
-				for(int d=0; d<dofs1; d++){
-					for (UN j=0; j < columnIndices1.size(); j++){
-		                columnIndices1[j] = GO ( dofs1 * mapFirstRow->getGlobalElement( element1.getNode(j) ) + d );
-						value1[j] = (*elementMatrix)[dofs1*i+di][dofs1*j+d];	
-					}
-			  		A->getBlock(0,0)->insertGlobalValues( row, columnIndices1(), value1() ); // Automatically adds entries if a value already exists 
-				}          
-            }
-		}
-		int offset= numNodes1*dofs1;
-
-
-        Teuchos::Array<SC> value( 1, 0. );
-        Teuchos::Array<GO> columnIndex( 1, 0 );
-        for (UN i=0; i < numNodes2 ; i++) {
-            for(int di=0; di<dofs2; di++){
-                GO row =GO (dofs2* mapSecondRow->getGlobalElement( element2.getNode(i) )+di);
-                for(int d=0; d<dofs2; d++){
-                    for (UN j=0; j < columnIndices2.size(); j++){
-                        double tmpValue =  (*elementMatrix)[offset+dofs2*i+di][offset+dofs2*j+d];
-                        if(std::fabs(tmpValue) > 1.e-13){
-                            columnIndex[0] = GO ( dofs2 * mapSecondRow->getGlobalElement( element2.getNode(j) ) + d );
-                            value[0] = tmpValue;
-                            A->getBlock(1,1)->insertGlobalValues( row, columnIndex(), value() ); // Automatically adds entries if a value already exists 
-
-                        }
-                    }
-                }          
-            }
-        }
-        
-		for (UN i=0; i < numNodes1; i++){
-			for(int di=0; di<dofs1; di++){				
-                GO row =GO (dofs1* mapFirstRow->getGlobalElement( element1.getNode(i) )+di);
-                for(int d=0; d<dofs2; d++){				
-                    for (UN j=0; j < numNodes2 ; j++) {
-                        value2[j] = (*elementMatrix)[i*dofs1+di][offset+j*dofs2+d];			    				    		
-                        columnIndices2[j] =GO (dofs2* mapSecondRow->getGlobalElement( element2.getNode(j) )+d);
-                    }
-                    A->getBlock(0,1)->insertGlobalValues( row, columnIndices2(), value2() ); // Automatically adds entries if a value already exists                            
-                }
-            }      
-		}
-
-        for (UN j=0; j < numNodes2; j++){
-            for(int di=0; di<dofs2; di++){	
-                GO row = GO (dofs2* mapSecondRow->getGlobalElement( element2.getNode(j) ) +di );
-                for(int d=0; d<dofs1; d++){				
-                    for (UN i=0; i < numNodes1 ; i++) {
-                        value1[i] = (*elementMatrix)[offset+j*dofs2+di][dofs1*i+d];			    				    		
-                        columnIndices1[i] =GO (dofs1* mapFirstRow->getGlobalElement( element1.getNode(i) )+d);
-                    }
-                    A->getBlock(1,0)->insertGlobalValues( row, columnIndices1(), value1() ); // Automatically adds entries if a value already exists                       
-                }    
-            }  
-		}
-
-
-}
-
-
-/*!
-
- \brief Assembly of Jacobian for NavierStokes 
-@param[in] dim Dimension
-@param[in] FEType FE Discretization
-@param[in] degree Degree of basis function
-@param[in] A Resulting matrix
-@param[in] callFillComplete If Matrix A should be completely filled at end of function
-@param[in] FELocExternal 
-
-*/
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::assemblyNavierStokes(int dim,
-	                                    std::string FETypeVelocity,
-	                                    std::string FETypePressure,
-	                                    int degree,
-										int dofsVelocity,
-										int dofsPressure,
-										MultiVectorPtr_Type u_rep,
-										MultiVectorPtr_Type p_rep,
-	                                    BlockMatrixPtr_Type &A,
-										BlockMultiVectorPtr_Type &resVec,
-										SmallMatrix_Type coeff,
- 										ParameterListPtr_Type params,
- 										bool reAssemble,
- 										std::string assembleMode,
-	                                    bool callFillComplete,
-	                                    int FELocExternal){
-	
-
-    UN FElocVel = checkFE(dim,FETypeVelocity); // Checks for different domains which belongs to a certain fetype
-    UN FElocPres = checkFE(dim,FETypePressure); // Checks for different domains which belongs to a certain fetype
-
-	ElementsPtr_Type elements = domainVec_.at(FElocVel)->getElementsC();
-
-	ElementsPtr_Type elementsPres = domainVec_.at(FElocPres)->getElementsC();
-
-	int dofsElement = elements->getElement(0).getVectorNodeList().size();
-
-	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FElocVel)->getPointsRepeated();
-
-	MapConstPtr_Type mapVel = domainVec_.at(FElocVel)->getMapRepeated();
-
-	MapConstPtr_Type mapPres = domainVec_.at(FElocPres)->getMapRepeated();
-
-	vec_dbl_Type solution(0);
-	vec_dbl_Type solution_u;
-	vec_dbl_Type solution_p;
-
-	vec_dbl_ptr_Type rhsVec;
-
-	/// Tupel construction follows follwing pattern:
-	/// std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e. "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per element)
-	int numVelo=3;
-    if(FETypeVelocity == "P2")
-        numVelo=6;
-        
-	if(dim==3){
-		numVelo=4;
-        if(FETypeVelocity == "P2")
-            numVelo=10;
-	}
-	tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
-	tuple_ssii_Type vel ("Velocity",FETypeVelocity,dofsVelocity,numVelo);
-	tuple_ssii_Type pres ("Pressure",FETypePressure,dofsPressure,dim+1);
-	problemDisk->push_back(vel);
-	problemDisk->push_back(pres);
-
-	if(assemblyFEElements_.size()== 0){
-        if(params->sublist("Material").get("Newtonian",true) == false)
-	 	    initAssembleFEElements("GeneralizedNewtonian",problemDisk,elements, params,pointsRep,domainVec_.at(FElocVel)->getElementMap()); // In cas of non Newtonian Fluid
-        else
-        	initAssembleFEElements("NavierStokes",problemDisk,elements, params,pointsRep,domainVec_.at(FElocVel)->getElementMap());
-    }
-	else if(assemblyFEElements_.size() != elements->numberElements())
-	     TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
-
-	//SmallMatrixPtr_Type elementMatrix =Teuchos::rcp( new SmallMatrix_Type( dofsElement));
-
-	MultiVectorPtr_Type resVec_u = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocVel)->getMapVecFieldRepeated(), 1 ) );
-    MultiVectorPtr_Type resVec_p = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocPres)->getMapRepeated(), 1 ) );
-	
-	BlockMultiVectorPtr_Type resVecRep = Teuchos::rcp( new BlockMultiVector_Type( 2) );
-	resVecRep->addBlock(resVec_u,0);
-	resVecRep->addBlock(resVec_p,1);
-
-
-	for (UN T=0; T<assemblyFEElements_.size(); T++) {
-		vec_dbl_Type solution(0);
-
-		solution_u = getSolution(elements->getElement(T).getVectorNodeList(), u_rep,dofsVelocity);
-		solution_p = getSolution(elementsPres->getElement(T).getVectorNodeList(), p_rep,dofsPressure);
-
-		solution.insert( solution.end(), solution_u.begin(), solution_u.end() );
-		solution.insert( solution.end(), solution_p.begin(), solution_p.end() );
-
-		assemblyFEElements_[T]->updateSolution(solution);
- 
- 		SmallMatrixPtr_Type elementMatrix;
-
-		if(assembleMode == "Jacobian"){
-			assemblyFEElements_[T]->assembleJacobian();
-		    
-            elementMatrix = assemblyFEElements_[T]->getJacobian(); 
-
-			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
-
-			if(reAssemble)
-				addFeBlock(A, elementMatrix, elements->getElement(T), mapVel, 0, 0, problemDisk);
-			else
-				addFeBlockMatrix(A, elementMatrix, elements->getElement(T), elementsPres->getElement(T), mapVel, mapPres, problemDisk);
-		}
-   		if(assembleMode == "FixedPoint"){
-            
-            //AssembleFENavierStokesPtr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFENavierStokes_Type>(assemblyFEElements_[T] ); // Why should we need a pointer we can directly call it using assemblyFEElements_[T]? Because assemblyFixedPoint is not a function of base class
-
-            if(params->sublist("Material").get("Newtonian",true) == false)
-            {
-                AssembleFEGeneralizedNewtonianPtr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFEGeneralizedNewtonian_Type>( assemblyFEElements_[T] );
-                elTmp->assembleFixedPoint();
-                elementMatrix =  elTmp->getFixedPointMatrix(); 
-            }
-            else // Newtonian Case
-            {
-              AssembleFENavierStokesPtr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFENavierStokes_Type>( assemblyFEElements_[T] );
-              elTmp->assembleFixedPoint();
-              elementMatrix =  elTmp->getFixedPointMatrix(); 
-            }
-            
-
-			assemblyFEElements_[T]->advanceNewtonStep(); // n genereal non linear solver step
-
-			if(reAssemble)
-				addFeBlock(A, elementMatrix, elements->getElement(T), mapVel, 0, 0, problemDisk);
-			else
-				addFeBlockMatrix(A, elementMatrix, elements->getElement(T), elementsPres->getElement(T),mapVel, mapPres, problemDisk);
-
-        }
-		if(assembleMode == "Rhs"){
-			AssembleFENavierStokesPtr_Type elTmp = Teuchos::rcp_dynamic_cast<AssembleFENavierStokes_Type>(assemblyFEElements_[T] );
-			elTmp->setCoeff(coeff);// Coeffs from time discretization. Right now default [1][1] // [0][0]
-		    assemblyFEElements_[T]->assembleRHS();
-		    rhsVec = assemblyFEElements_[T]->getRHS(); 
-			addFeBlockMv(resVecRep, rhsVec, elements->getElement(T),elementsPres->getElement(T), dofsVelocity,dofsPressure);
-		}
-
-			
-	}
-	if (callFillComplete && reAssemble && assembleMode != "Rhs" )
-	    A->getBlock(0,0)->fillComplete( domainVec_.at(FElocVel)->getMapVecFieldUnique(),domainVec_.at(FElocVel)->getMapVecFieldUnique());
-	else if(callFillComplete && !reAssemble && assembleMode != "Rhs"){
-		A->getBlock(0,0)->fillComplete();
-	    A->getBlock(1,0)->fillComplete(domainVec_.at(FElocVel)->getMapVecFieldUnique(),domainVec_.at(FElocPres)->getMapUnique());
-	    A->getBlock(0,1)->fillComplete(domainVec_.at(FElocPres)->getMapUnique(),domainVec_.at(FElocVel)->getMapVecFieldUnique());
-	}
-
-	if(assembleMode == "Rhs"){
-
-		MultiVectorPtr_Type resVecUnique_u = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocVel)->getMapVecFieldUnique(), 1 ) );
-		MultiVectorPtr_Type resVecUnique_p = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocPres)->getMapUnique(), 1 ) );
-
-		resVecUnique_u->putScalar(0.);
-		resVecUnique_p->putScalar(0.);
-
-		resVecUnique_u->exportFromVector( resVec_u, true, "Add" );
-		resVecUnique_p->exportFromVector( resVec_p, true, "Add" );
-
-		resVec->addBlock(resVecUnique_u,0);
-		resVec->addBlock(resVecUnique_p,1);
-	}
-
-
-}
-
-
-/*!
- \brief  Method to loop over all assembleFESpecific elements and set the defined linearization 
-@param[in] string linearization e.g. "Picard" or "Newton"
-*/
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::changeLinearizationFE(std::string linearization)
-{
-    for (UN T=0; T<assemblyFEElements_.size(); T++) // For each assembledFEElement change Linearization
-    {	
-        assemblyFEElements_[T]->changeLinearization(linearization);
-    }
-}
-
-
-/*!
- \brief Postprocessing: Using a converged velocity solution -> compute averaged viscosity inside an element at center of mass
-@param[in] dim Dimension
-@param[in] FEType FE Discretization
-@param[in] degree Degree of basis function
-@param[in] repeated solution fields for u and p
-@param[in] parameter lists
-*/
-
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::computeSteadyViscosityFE_CM(int dim,
-	                                    std::string FETypeVelocity,
-	                                    std::string FETypePressure,
-										int dofsVelocity,
-										int dofsPressure,
-										MultiVectorPtr_Type u_rep,
-										MultiVectorPtr_Type p_rep,
- 										ParameterListPtr_Type params){
-	
-
-    UN FElocVel = checkFE(dim,FETypeVelocity); // Checks for different domains which belongs to a certain fetype
-    UN FElocPres = checkFE(dim,FETypePressure); // Checks for different domains which belongs to a certain fetype
-
-	ElementsPtr_Type elements = domainVec_.at(FElocVel)->getElementsC();
-	ElementsPtr_Type elementsPres = domainVec_.at(FElocPres)->getElementsC();
-
-	vec_dbl_Type solution(0);
-	vec_dbl_Type solution_u;
-	vec_dbl_Type solution_p;
-    vec_dbl_Type solution_viscosity;
-
-    // We have to compute viscosity solution in each element 
-	MultiVectorPtr_Type Sol_viscosity = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FElocVel)->getElementMap(), 1 ) ); //
-    BlockMultiVectorPtr_Type visco_output = Teuchos::rcp( new BlockMultiVector_Type(1) );
-    visco_output->addBlock(Sol_viscosity,0);
-   
-
-	for (UN T=0; T<assemblyFEElements_.size(); T++) {
-       
-		vec_dbl_Type solution(0);
-		solution_u = getSolution(elements->getElement(T).getVectorNodeList(), u_rep,dofsVelocity); // get the solution inside an element on the nodes
-		solution_p = getSolution(elementsPres->getElement(T).getVectorNodeList(), p_rep,dofsPressure);
-
-		solution.insert( solution.end(), solution_u.begin(), solution_u.end() ); // here we insert the solution
-		solution.insert( solution.end(), solution_p.begin(), solution_p.end() );
-
-		assemblyFEElements_[T]->updateSolution(solution); // here we update the value of the solutions inside an element
- 
-        assemblyFEElements_[T]->computeLocalconstOutputField(); //  we compute the viscosity inside an element
-        solution_viscosity = assemblyFEElements_[T]->getLocalconstOutputField();
-
-        Teuchos::ArrayRCP<SC>  resArray_block = visco_output->getBlockNonConst(0)->getDataNonConst(0); // First 
-        resArray_block[T] = solution_viscosity[0]; // although it is a vector it only has one entry because we compute the value in the center of the element
-          
-	} // end loop over all elements
-    // We could also instead of just overwrite it add an aditional block such that we could also compute other output fields and save it in there
-    this->const_output_fields= visco_output;
-
-
-}
-
-
-
-/*!
-
- \brief Inserting local rhsVec into global residual Mv;
-
-
-@param[in] res BlockMultiVector of residual vec; Repeated distribution; 2 blocks
-@param[in] rhsVec sorted the same way as residual vec
-@param[in] element of block1
-
-*/
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::addFeBlockMv(BlockMultiVectorPtr_Type &res, vec_dbl_ptr_Type rhsVec, FiniteElement elementBlock1,FiniteElement elementBlock2, int dofs1, int dofs2 ){
-
-    Teuchos::ArrayRCP<SC>  resArray_block1 = res->getBlockNonConst(0)->getDataNonConst(0);
-
-    Teuchos::ArrayRCP<SC>  resArray_block2 = res->getBlockNonConst(1)->getDataNonConst(0);
-
-	vec_LO_Type nodeList_block1 = elementBlock1.getVectorNodeList();
-
-	vec_LO_Type nodeList_block2 = elementBlock2.getVectorNodeList();
-
-	for(int i=0; i< nodeList_block1.size() ; i++){
-		for(int d=0; d<dofs1; d++){
-			resArray_block1[nodeList_block1[i]*dofs1+d] += (*rhsVec)[i*dofs1+d];
-        }
-	}
-	int offset = nodeList_block1.size()*dofs1;
-
-	for(int i=0; i < nodeList_block2.size(); i++){
-		for(int d=0; d<dofs2; d++)
-			resArray_block2[nodeList_block2[i]*dofs2+d] += (*rhsVec)[i*dofs2+d+offset];
-	}
-
-}
-
-
-/*!
-
- \brief Adding FEBlock (row,column) to FE Blockmatrix
-TODO: column indices pre determine
-
-@param[in] &A Global Block Matrix
-@param[in] elementMatrix Stiffness matrix of one element
-@param[in] element Corresponding finite element
-@param[in] map Map that corresponds to repeated nodes of first block
-@param[in] map Map that corresponds to repeated nodes of second block
-
-*/
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::addFeBlock(BlockMatrixPtr_Type &A, SmallMatrixPtr_Type elementMatrix, FiniteElement element, MapConstPtr_Type mapRow, int row, int column, tuple_disk_vec_ptr_Type problemDisk){
-		
-		int dofs1 = std::get<2>(problemDisk->at(row));
-
-		int numNodes1 = std::get<3>(problemDisk->at(row));
-
-		int dofsBlock1 = dofs1*numNodes1;
-
-		Teuchos::Array<SC> value( numNodes1, 0. );
-        Teuchos::Array<GO> columnIndices( numNodes1, 0 );
-
-		for (UN i=0; i < numNodes1 ; i++) {
-			for(int di=0; di<dofs1; di++){
-				GO rowID =GO (dofs1* mapRow->getGlobalElement( element.getNode(i) )+di);
-				for(int d=0; d<dofs1; d++){
-					for (UN j=0; j < columnIndices.size(); j++){
-		                columnIndices[j] = GO ( dofs1 * mapRow->getGlobalElement( element.getNode(j) ) + d );
-						value[j] = (*elementMatrix)[dofs1*i+di][dofs1*j+d];	
-					}
-			  		A->getBlock(row,column)->insertGlobalValues( rowID, columnIndices(), value() ); // Automatically adds entries if a value already exists 
-				}          
-            }
-		}
-}
-
-/*!
-
- \brief Initialization of vector consisting of the assembleFE Elements. Follows structure of 'normal' elements, i.e. elementMap also applicable
-
-@param[in] elementType i.e. Laplace, Navier Stokes..
-@param[in] problemDisk Tuple of specific problem Information
-@param[in] elements
-@param[in] params parameter list
-
-*/
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::initAssembleFEElements(std::string elementType,tuple_disk_vec_ptr_Type problemDisk,ElementsPtr_Type elements, ParameterListPtr_Type params,vec2D_dbl_ptr_Type pointsRep, MapConstPtr_Type elementMap){
-    
-	vec2D_dbl_Type nodes;
-	for (UN T=0; T<elements->numberElements(); T++) {
-		
-		nodes = getCoordinates(elements->getElement(T).getVectorNodeList(), pointsRep);
-
-		AssembleFEFactory<SC,LO,GO,NO> assembleFEFactory;
-
-		AssembleFEPtr_Type assemblyFE = assembleFEFactory.build(elementType,elements->getElement(T).getFlag(),nodes, params,problemDisk);
-        //  
-        assemblyFE->setGlobalElementID(elementMap->getGlobalElement(T));
-
-		assemblyFEElements_.push_back(assemblyFE);
-
-	}
-
-}
-
-/*!
-
- \brief Returns coordinates of local node ids
-
-@param[in] localIDs
-@param[in] points
-@param[out] coordinates 
-
-*/
-
-template <class SC, class LO, class GO, class NO>
-vec2D_dbl_Type FE<SC,LO,GO,NO>::getCoordinates(vec_LO_Type localIDs, vec2D_dbl_ptr_Type points){
-
-	vec2D_dbl_Type coordinates(0,vec_dbl_Type( points->at(0).size()));
-	for(int i=0; i < localIDs.size() ; i++){
-		coordinates.push_back(points->at(localIDs[i]));
-	}
-
-    return coordinates;
-}
-
-/*!
-
- \brief Returns entries of u of element
-
-@param[in] localIDs
-@param[in] points
-@param[out] coordinates 
-
-*/
-
-template <class SC, class LO, class GO, class NO>
-vec_dbl_Type FE<SC,LO,GO,NO>::getSolution(vec_LO_Type localIDs, MultiVectorPtr_Type u_rep, int dofsVelocity){
-
-    Teuchos::ArrayRCP<SC>  uArray = u_rep->getDataNonConst(0);
-	
-	vec_dbl_Type solution(0);
-	for(int i=0; i < localIDs.size() ; i++){
-		for(int d=0; d<dofsVelocity; d++)
-			solution.push_back(uArray[localIDs[i]*dofsVelocity+d]);
-	}
-
-    return solution;
 }
 
 
@@ -1483,10 +101,7 @@ void FE<SC,LO,GO,NO>::applyBTinv( vec3D_dbl_ptr_Type& dPhiIn,
     }
 }
     
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::assemblyEmptyMatrix(MatrixPtr_Type &A){
-    A->fillComplete();
-}
+
 template <class SC, class LO, class GO, class NO>
 void FE<SC,LO,GO,NO>::assemblyIdentity(MatrixPtr_Type &A){
     Teuchos::Array<SC> value(1, Teuchos::ScalarTraits<SC>::one() );
@@ -1510,12 +125,12 @@ void FE<SC,LO,GO,NO>::assemblySurfaceRobinBC(int dim,
                                               RhsFunc_Type func,
                                               ParameterListPtr_Type parameters){
 
-    ElementsPtr_Type elements = domainVec_.at(1)->getElementsC();
-    ElementsPtr_Type elementsV = domainVec_.at(0)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(1)->getElementsC();
+    ElementsPtr_Type elementsV = this->domainVec_.at(0)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(1)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(1)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(1)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(1)->getMapRepeated();
 
     vec2D_dbl_ptr_Type     phi,phiV;
     vec_dbl_ptr_Type    weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -1619,13 +234,13 @@ void FE<SC,LO,GO,NO>::assemblySurfaceRobinBC(int dim,
 //     //TEUCHOS_TEST_FOR_EXCEPTION( u->getNumVectors()>1, std::logic_error, "Implement for numberMV > 1 ." );
 //     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     
-//     UN FEloc = checkFE(dim,FEType);
+//     UN FEloc = this->checkFE(dim,FEType);
     
-// 	ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+// 	ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-// 	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+// 	vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-// 	MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+// 	MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
 // 	vec2D_dbl_ptr_Type     phi;
 // 	vec_dbl_ptr_Type    weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -1676,7 +291,7 @@ void FE<SC,LO,GO,NO>::assemblySurfaceRobinBC(int dim,
 //                 reactionFunc(&value[j], &valueFunc[0] ,paras);
 
 //                 value[j] *= valueFunc[0] * absDetB;
-//                 if (setZeros_ && std::fabs(value[j]) < myeps_) {
+//                 if (this->setZeros_ && std::fabs(value[j]) < this->myeps_) {
 //                     value[j] = 0.;
 //                 }
 //                 indices[j] = GO( map->getGlobalElement( elements->getElement(T).getNode(j) ));
@@ -1707,13 +322,13 @@ void FE<SC,LO,GO,NO>::assemblySurfaceRobinBC(int dim,
 //     //TEUCHOS_TEST_FOR_EXCEPTION( u->getNumVectors()>1, std::logic_error, "Implement for numberMV > 1 ." );
 //     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     
-//     UN FEloc = checkFE(dim,FEType);
+//     UN FEloc = this->checkFE(dim,FEType);
     
-// 	ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+// 	ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-// 	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+// 	vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-// 	MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+// 	MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
 // 	vec2D_dbl_ptr_Type     phi;
 // 	vec_dbl_ptr_Type    weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -1750,7 +365,7 @@ void FE<SC,LO,GO,NO>::assemblySurfaceRobinBC(int dim,
 //                 reactionFunc(&value[j], &valueFunc[0] ,paras);
 
 //                 value[j] *= valueFunc[0] * absDetB;
-//                 if (setZeros_ && std::fabs(value[j]) < myeps_) {
+//                 if (this->setZeros_ && std::fabs(value[j]) < this->myeps_) {
 //                     value[j] = 0.;
 //                 }
 //                 indices[j] = GO( map->getGlobalElement( elements->getElement(T).getNode(j) ));
@@ -1782,13 +397,13 @@ void FE<SC,LO,GO,NO>::assemblySurfaceRobinBC(int dim,
 //     //TEUCHOS_TEST_FOR_EXCEPTION( u->getNumVectors()>1, std::logic_error, "Implement for numberMV > 1 ." );
 //     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     
-//     UN FEloc = checkFE(dim,FEType);
+//     UN FEloc = this->checkFE(dim,FEType);
     
-// 	ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+// 	ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-// 	vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+// 	vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-// 	MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+// 	MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
 // 	vec2D_dbl_ptr_Type     phi;
 //     vec3D_dbl_ptr_Type 	dPhi;
@@ -1849,7 +464,7 @@ void FE<SC,LO,GO,NO>::assemblySurfaceRobinBC(int dim,
 //                 reactionFunc(&value[j], &valueFunc[0] ,paras);
 
 //                 value[j] *= valueFunc[0] * absDetB;
-//                 if (setZeros_ && std::fabs(value[j]) < myeps_) {
+//                 if (this->setZeros_ && std::fabs(value[j]) < this->myeps_) {
 //                     value[j] = 0.;
 //                 }
 //                 indices[j] = GO( map->getGlobalElement( elements->getElement(T).getNode(j) ));
@@ -1864,52 +479,7 @@ void FE<SC,LO,GO,NO>::assemblySurfaceRobinBC(int dim,
 //         A->fillComplete();
 // }
 
-/*!
- \brief Assembly of constant stiffness matix for laplacian operator \f$ \Delta \f$
-@param[in] dim Dimension
-@param[in] FEType FE Discretization
-@param[in] degree Degree of basis function
-@param[in] A Resulting matrix
-@param[in] callFillComplete If Matrix A should be completely filled at end of function
-@param[in] FELocExternal 
-*/
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::assemblyLaplaceAssFE(int dim,
-                                        std::string FEType,
-                                        int degree,
-                                        int dofs,
-                                        BlockMatrixPtr_Type &A,
-                                        bool callFillComplete,
-                                        int FELocExternal){
-    ParameterListPtr_Type params = Teuchos::getParametersFromXmlFile("parametersProblemLaplace.xml");
 
-    UN FEloc = checkFE(dim,FEType);
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
-    vec2D_dbl_Type nodes;
-    int numNodes=dim+1;
-    if(FEType == "P2"){
-        numNodes= 6;
-        if(dim==3)
-            numNodes=10;
-    }
-    tuple_disk_vec_ptr_Type problemDisk = Teuchos::rcp(new tuple_disk_vec_Type(0));
-    tuple_ssii_Type vel ("Laplace",FEType,dofs,numNodes); 
-    problemDisk->push_back(vel);
-    if(assemblyFEElements_.size()== 0)
-        initAssembleFEElements("Laplace",problemDisk,elements, params,pointsRep,domainVec_.at(0)->getElementMap());
-    else if(assemblyFEElements_.size() != elements->numberElements())
-         TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "Number Elements not the same as number assembleFE elements." );
-    for (UN T=0; T<elements->numberElements(); T++) {
-        assemblyFEElements_[T]->assembleJacobian();
-        SmallMatrixPtr_Type elementMatrix = assemblyFEElements_[T]->getJacobian(); 
-      	addFeBlock(A, elementMatrix, elements->getElement(T), map, 0, 0, problemDisk);
-
-    }
-    if(callFillComplete)
-        A->getBlock(0,0)->fillComplete();
-}
 
 
 template <class SC, class LO, class GO, class NO>
@@ -1923,15 +493,15 @@ void FE<SC,LO,GO,NO>::assemblyLaplaceDiffusion(int dim,
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     UN FEloc;
     if (FELocExternal<0)
-        FEloc = checkFE(dim,FEType);
+        FEloc = this->checkFE(dim,FEType);
     else
         FEloc = FELocExternal;
     
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 	dPhi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -1990,7 +560,7 @@ void FE<SC,LO,GO,NO>::assemblyLaplaceDiffusion(int dim,
                 }
                 value[j] *= absDetB;
                 indices[j] = map->getGlobalElement( elements->getElement(T).getNode(j) );
-                if (setZeros_ && std::fabs(value[j]) < myeps_) {
+                if (this->setZeros_ && std::fabs(value[j]) < this->myeps_) {
                     value[j] = 0.;
                 }
             }
@@ -2043,14 +613,14 @@ void FE<SC,LO,GO,NO>::applyDiff( vec3D_dbl_Type& dPhiIn,
 
 //     std::string tpmType = parameterList->sublist("Parameter").get("TPM Type","Biot");
     
-//     int dim = domainVec_[0]->getDimension();
+//     int dim = this->domainVec_[0]->getDimension();
 //     int idata = 1; //= we should init this
 //     int ic = -1; int ng = -1;
     
 //     //ed.hp:history previous (timestep); previous solution (velocity and acceleration)
 //     //ed.ht:? same length as hp
-//     ElementsPtr_Type elements1 = domainVec_[0]->getElementsC();
-//     ElementsPtr_Type elements2 = domainVec_[1]->getElementsC();
+//     ElementsPtr_Type elements1 = this->domainVec_[0]->getElementsC();
+//     ElementsPtr_Type elements2 = this->domainVec_[1]->getElementsC();
     
 //     int sizeED = 24; /* 2D case for P2 elements:
 //                       12 velocities, 12 accelerations (2 dof per P2 node)
@@ -2165,8 +735,8 @@ void FE<SC,LO,GO,NO>::applyDiff( vec3D_dbl_Type& dPhiIn,
 //     }
     
 //     GO offsetMap1 = dim * mapRepeated1->getMaxAllGlobalIndex()+1;
-//     vec2D_dbl_ptr_Type pointsRepU = domainVec_.at(0)->getPointsRepeated();
-//     vec2D_dbl_ptr_Type pointsRepP = domainVec_.at(1)->getPointsRepeated();
+//     vec2D_dbl_ptr_Type pointsRepU = this->domainVec_.at(0)->getPointsRepeated();
+//     vec2D_dbl_ptr_Type pointsRepP = this->domainVec_.at(1)->getPointsRepeated();
     
 //     Teuchos::ArrayRCP< const SC > uArrayNewton = u_repeatedNewton->getData(0);
 //     Teuchos::ArrayRCP< const SC > pArrayNewton = p_repeatedNewton->getData(0);
@@ -2353,12 +923,12 @@ void FE<SC,LO,GO,NO>::assemblyMass(int dim,
                                      bool callFillComplete){
 
     TEUCHOS_TEST_FOR_EXCEPTION( FEType == "P0", std::logic_error, "Not implemented for P0" );
-    UN FEloc = checkFE(dim,FEType);
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    UN FEloc = this->checkFE(dim,FEType);
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec2D_dbl_ptr_Type 	phi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -2420,7 +990,7 @@ void FE<SC,LO,GO,NO>::assemblyMass(int dim,
 
 
 // Ueberladung der Assemblierung der Massematrix fuer FSI, da
-// checkFE sonst auch fuer das Strukturproblem FEloc = 1 liefert (= Fluid)
+// this->checkFE sonst auch fuer das Strukturproblem FEloc = 1 liefert (= Fluid)
 // und somit die welche domain und Map in der Assemblierung genutzt wird.
 template <class SC, class LO, class GO, class NO>
 void FE<SC,LO,GO,NO>::assemblyMass(int dim,
@@ -2432,11 +1002,11 @@ void FE<SC,LO,GO,NO>::assemblyMass(int dim,
 
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec2D_dbl_ptr_Type 	phi;
     vec_dbl_ptr_Type	weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -2506,15 +1076,15 @@ void FE<SC,LO,GO,NO>::assemblyLaplace(int dim,
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     UN FEloc;
     if (FELocExternal<0)
-        FEloc = checkFE(dim,FEType);
+        FEloc = this->checkFE(dim,FEType);
     else
         FEloc = FELocExternal;
     
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 	dPhi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -2570,13 +1140,13 @@ void FE<SC,LO,GO,NO>::assemblyLaplaceVecField(int dim,
                                                 bool callFillComplete){
 
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P1-disc" || FEType == "P0",std::logic_error, "Not implemented for P0 or P1-disc");
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 	dPhi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -2612,7 +1182,7 @@ void FE<SC,LO,GO,NO>::assemblyLaplaceVecField(int dim,
                         value[j] += weights->at(w) * dPhiTrans[w][i][d] * dPhiTrans[w][j][d];
                 }
                 value[j] *= absDetB;
-                if (setZeros_ && std::fabs(value[j]) < myeps_) {
+                if (this->setZeros_ && std::fabs(value[j]) < this->myeps_) {
                     value[j] = 0.;
                 }
             }
@@ -2637,13 +1207,13 @@ void FE<SC,LO,GO,NO>::assemblyLaplaceVecFieldV2(int dim,
                                                 bool callFillComplete){
 
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 	dPhi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -2729,133 +1299,6 @@ void FE<SC,LO,GO,NO>::assemblyLaplaceVecFieldV2(int dim,
         A->fillComplete();
 }
 
-/*!
- \brief Assembly of Jacobian for nonlinear Laplace example
-@param[in] dim Dimension
-@param[in] FEType FE Discretization
-@param[in] degree Degree of basis function
-@param[in] u_rep The current solution
-@param[in] A Resulting matrix
-@param[in] resVec Resulting residual
-@param[in] params Params needed by the problem. Placeholder for now.
-@param[in] assembleMode What should be assembled i.e. Rhs (residual) or the
-Jacobian
-@param[in] callFillComplete If Matrix A should be redistributed across MPI procs
-at end of function
-@param[in] FELocExternal ?
-*/
-
-template <class SC, class LO, class GO, class NO>
-void FE<SC, LO, GO, NO>::assemblyNonlinearLaplace(
-    int dim, std::string FEType, int degree, MultiVectorPtr_Type u_rep,
-    BlockMatrixPtr_Type &A, BlockMultiVectorPtr_Type &resVec,
-    ParameterListPtr_Type params, std::string assembleMode, bool callFillComplete,
-    int FELocExternal) {
-
-    ElementsPtr_Type elements = this->domainVec_.at(0)->getElementsC();
-
-    // Only scalar laplace
-    int dofs = 1;
-
-    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(0)->getPointsRepeated();
-    MapConstPtr_Type map = this->domainVec_.at(0)->getMapRepeated();
-
-    vec_dbl_Type solution_u;
-    vec_dbl_ptr_Type rhsVec;
-
-    int numNodes = 3;
-    if (FEType == "P2") {
-        numNodes = 6;
-    }
-    if (dim == 3) {
-        numNodes = 4;
-        if (FEType == "P2") {
-            numNodes = 10;
-        }
-    }
-
-    // Tupel construction follows follwing pattern:
-    // std::string: Physical Entity (i.e. Velocity) , std::string: Discretisation (i.e.
-    // "P2"), int: Degrees of Freedom per Node, int: Number of Nodes per
-    // element)
-    tuple_disk_vec_ptr_Type problemDisk =
-        Teuchos::rcp(new tuple_disk_vec_Type(0));
-    tuple_ssii_Type temp("Solution", FEType, dofs, numNodes);
-    problemDisk->push_back(temp);
-
-    // Construct an assembler for each element if not already done
-    if (assemblyFEElements_.size() == 0) {
-        initAssembleFEElements("NonLinearLaplace", problemDisk, elements, params, pointsRep, domainVec_.at(0)->getElementMap());
-    } else if (assemblyFEElements_.size() != elements->numberElements()) {
-        TEUCHOS_TEST_FOR_EXCEPTION(
-            true, std::logic_error,
-            "Number Elements not the same as number assembleFE elements.");
-    }
-
-    MultiVectorPtr_Type resVec_u;
-    BlockMultiVectorPtr_Type resVecRep;
-
-    if (assembleMode != "Rhs") {
-        // add new or overwrite existing block (0,0) of system matrix
-        // This is done in specific problem class for most other problems
-        // Placing it here instead as more fitting
-        auto A_block_zero_zero = Teuchos::rcp(
-            new Matrix_Type(this->domainVec_.at(0)->getMapUnique(), this->domainVec_.at(0)->getApproxEntriesPerRow()));
-
-        A->addBlock(A_block_zero_zero, 0, 0);
-    } else {
-        // Or same for the residual vector
-        resVec_u = Teuchos::rcp(new MultiVector_Type(map, 1));
-        resVecRep = Teuchos::rcp(new BlockMultiVector_Type(1));
-        resVecRep->addBlock(resVec_u, 0);
-    }
-    // Call assembly routines on each element
-    for (UN T = 0; T < assemblyFEElements_.size(); T++) {
-        vec_dbl_Type solution(0);
-
-        // Update solution on the element
-        solution_u = getSolution(elements->getElement(T).getVectorNodeList(),
-                                 u_rep, dofs);
-        solution.insert(solution.end(), solution_u.begin(), solution_u.end());
-        assemblyFEElements_[T]->updateSolution(solution);
-
-        if (assembleMode == "Jacobian") {
-            SmallMatrixPtr_Type elementMatrix;
-            assemblyFEElements_[T]->assembleJacobian();
-            elementMatrix = assemblyFEElements_[T]->getJacobian();
-            // Insert (additive) the local element Jacobian into the global
-            // matrix
-            assemblyFEElements_[T]
-                ->advanceNewtonStep(); // n genereal non linear solver step
-            addFeBlock(A, elementMatrix, elements->getElement(T), map, 0, 0,
-                       problemDisk);
-        }
-
-        if (assembleMode == "Rhs") {
-            assemblyFEElements_[T]->assembleRHS();
-            rhsVec = assemblyFEElements_[T]->getRHS();
-            // Name RHS comes from solving linear systems
-            // For nonlinear systems RHS synonymous to residual
-            // Insert (additive) the updated residual into the global residual
-            // vector
-            addFeBlockMv(resVecRep, rhsVec, elements->getElement(T), dofs);
-        }
-    }
-    if (callFillComplete && assembleMode != "Rhs") {
-        // Signal that editing A has finished. This causes the entries of A to
-        // be redistributed across the MPI ranks
-        A->getBlock(0, 0)->fillComplete(domainVec_.at(0)->getMapUnique(),
-                                        domainVec_.at(0)->getMapUnique());
-    }
-    if (assembleMode == "Rhs") {
-        // Export from overlapping residual to unique residual
-        MultiVectorPtr_Type resVecUnique = Teuchos::rcp(
-            new MultiVector_Type(domainVec_.at(0)->getMapUnique(), 1));
-        resVecUnique->putScalar(0.);
-        resVecUnique->exportFromVector(resVec_u, true, "Add");
-        resVec->addBlock(resVecUnique, 0);
-    }
-}
 
 
 template <class SC, class LO, class GO, class NO>
@@ -2868,13 +1311,13 @@ void FE<SC,LO,GO,NO>::assemblyElasticityJacobianAndStressAceFEM(int dim,
                                                                 double C,
                                                                 bool callFillComplete){
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::runtime_error, "Not implemented for P0");
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
     
     
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
     vec3D_dbl_ptr_Type 	dPhi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
     
@@ -3327,13 +1770,13 @@ void FE<SC,LO,GO,NO>::assemblyElasticityJacobianAceFEM(int dim,
                                                   double C,
                                                   bool callFillComplete){
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    vec2D_int_ptr_Type elements = domainVec_.at(FEloc)->getElements();
+    vec2D_int_ptr_Type elements = this->domainVec_.at(FEloc)->getElements();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
     vec3D_dbl_ptr_Type 	dPhi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
 
@@ -3531,13 +1974,13 @@ void FE<SC,LO,GO,NO>::assemblyElasticityStressesAceFEM(int dim,
                                                              double C,
                                                              bool callFillComplete){
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    vec2D_int_ptr_Type elements = domainVec_.at(FEloc)->getElements();
+    vec2D_int_ptr_Type elements = this->domainVec_.at(FEloc)->getElements();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 	dPhi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -3716,13 +2159,13 @@ void FE<SC,LO,GO,NO>::assemblyAdvectionVecField(int dim,
     TEUCHOS_TEST_FOR_EXCEPTION( u->getNumVectors()>1, std::logic_error, "Implement for numberMV > 1 ." );
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type     dPhi;
     vec2D_dbl_ptr_Type     phi;
@@ -3777,7 +2220,7 @@ void FE<SC,LO,GO,NO>::assemblyAdvectionVecField(int dim,
                         
                 }
                 value[j] *= absDetB;
-                if (setZeros_ && std::fabs(value[j]) < myeps_) {
+                if (this->setZeros_ && std::fabs(value[j]) < this->myeps_) {
                     value[j] = 0.;
                 }
 
@@ -3809,13 +2252,13 @@ void FE<SC,LO,GO,NO>::assemblyAdvectionInUVecField(int dim,
 
     TEUCHOS_TEST_FOR_EXCEPTION( u->getNumVectors()>1, std::logic_error, "Implement for numberMV > 1 ." );
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 	dPhi;
     vec2D_dbl_ptr_Type 	phi;
@@ -3870,7 +2313,7 @@ void FE<SC,LO,GO,NO>::assemblyAdvectionInUVecField(int dim,
                         }
                         value[ dim * j + d2 ] *= absDetB;
 
-                        if (setZeros_ && std::fabs(value[ dim * j + d2 ]) < myeps_) {
+                        if (this->setZeros_ && std::fabs(value[ dim * j + d2 ]) < this->myeps_) {
                             value[ dim * j + d2 ] = 0.;
                         }
                     }
@@ -3902,14 +2345,14 @@ void FE<SC,LO,GO,NO>::assemblyAdvectionVecFieldScalar(int dim,
     TEUCHOS_TEST_FOR_EXCEPTION( u->getNumVectors()>1, std::logic_error, "Implement for numberMV > 1 ." );
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(1)->getElementsC();
-    ElementsPtr_Type elementsVel = domainVec_.at(0)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(1)->getElementsC();
+    ElementsPtr_Type elementsVel = this->domainVec_.at(0)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(1)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(1)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(1)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(1)->getMapRepeated();
 
     vec3D_dbl_ptr_Type     dPhi;
     vec2D_dbl_ptr_Type     phi,phiV;
@@ -3990,21 +2433,21 @@ void FE<SC,LO,GO,NO>::assemblyDivAndDivT( int dim,
                                             bool callFillComplete) {
 
 
-    UN FEloc1 = checkFE(dim,FEType1);
-    UN FEloc2 = checkFE(dim,FEType2);
+    UN FEloc1 = this->checkFE(dim,FEType1);
+    UN FEloc2 = this->checkFE(dim,FEType2);
 
-    ElementsPtr_Type elements1 = domainVec_.at(FEloc1)->getElementsC();
-    ElementsPtr_Type elements2 = domainVec_.at(FEloc2)->getElementsC();
+    ElementsPtr_Type elements1 = this->domainVec_.at(FEloc1)->getElementsC();
+    ElementsPtr_Type elements2 = this->domainVec_.at(FEloc2)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep1 = domainVec_.at(FEloc1)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep1 = this->domainVec_.at(FEloc1)->getPointsRepeated();
 
-    MapConstPtr_Type mapping1 = domainVec_.at(FEloc1)->getMapRepeated();
+    MapConstPtr_Type mapping1 = this->domainVec_.at(FEloc1)->getMapRepeated();
     MapConstPtr_Type mapping2;
 
     if (FEType2 == "P0")
-        mapping2 = domainVec_.at(FEloc2)->getElementMap();
+        mapping2 = this->domainVec_.at(FEloc2)->getElementMap();
     else
-        mapping2 = domainVec_.at(FEloc2)->getMapRepeated();
+        mapping2 = this->domainVec_.at(FEloc2)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 	dPhi;
     vec2D_dbl_ptr_Type 	phi;
@@ -4050,7 +2493,7 @@ void FE<SC,LO,GO,NO>::assemblyDivAndDivT( int dim,
                 }
                 for (UN d=0; d<dim; d++){
                     valueVec[d][j] *= absDetB;
-                    if (setZeros_ && std::fabs(valueVec[d][j]) < myeps_) {
+                    if (this->setZeros_ && std::fabs(valueVec[d][j]) < this->myeps_) {
                         valueVec[d][j] = 0.;
                     }
                 }
@@ -4080,7 +2523,7 @@ void FE<SC,LO,GO,NO>::assemblyDivAndDivT( int dim,
                 }
                 for (UN d=0; d<dim; d++){
                     valueVec[d][j] *= absDetB;
-                    if (setZeros_ && std::fabs(valueVec[d][j]) < myeps_) {
+                    if (this->setZeros_ && std::fabs(valueVec[d][j]) < this->myeps_) {
                         valueVec[d][j] = 0.;
                     }
                 }
@@ -4120,21 +2563,21 @@ void FE<SC,LO,GO,NO>::assemblyDivAndDivTFast( int dim,
                                              bool callFillComplete) {
     
     
-    UN FEloc1 = checkFE(dim,FEType1);
-    UN FEloc2 = checkFE(dim,FEType2);
+    UN FEloc1 = this->checkFE(dim,FEType1);
+    UN FEloc2 = this->checkFE(dim,FEType2);
     
-    ElementsPtr_Type elements1 = domainVec_.at(FEloc1)->getElementsC();
-    ElementsPtr_Type elements2 = domainVec_.at(FEloc2)->getElementsC();
+    ElementsPtr_Type elements1 = this->domainVec_.at(FEloc1)->getElementsC();
+    ElementsPtr_Type elements2 = this->domainVec_.at(FEloc2)->getElementsC();
     
-    vec2D_dbl_ptr_Type pointsRep1 = domainVec_.at(FEloc1)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep1 = this->domainVec_.at(FEloc1)->getPointsRepeated();
     
-    MapConstPtr_Type mapping1 = domainVec_.at(FEloc1)->getMapRepeated();
+    MapConstPtr_Type mapping1 = this->domainVec_.at(FEloc1)->getMapRepeated();
     MapConstPtr_Type mapping2;
     
     if (FEType2 == "P0")
-        mapping2 = domainVec_.at(FEloc2)->getElementMap();
+        mapping2 = this->domainVec_.at(FEloc2)->getElementMap();
     else
-        mapping2 = domainVec_.at(FEloc2)->getMapRepeated();
+        mapping2 = this->domainVec_.at(FEloc2)->getMapRepeated();
     
     vec3D_dbl_ptr_Type 	dPhi;
     vec2D_dbl_ptr_Type 	phi;
@@ -4209,13 +2652,13 @@ void FE<SC,LO,GO,NO>::assemblyBDStabilization(int dim,
                                               bool callFillComplete){
      
     TEUCHOS_TEST_FOR_EXCEPTION(FEType != "P1" && FEType != "Q1",std::logic_error, "Only implemented for P1, Q1.");
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec2D_dbl_ptr_Type 	phi;
 
@@ -4296,7 +2739,7 @@ void FE<SC,LO,GO,NO>::assemblyLaplaceXDim(int dim,
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     int FEloc = this->checkFE(dim,FEType);
 
-    DomainConstPtr_Type domain = domainVec_.at(FEloc);
+    DomainConstPtr_Type domain = this->domainVec_.at(FEloc);
     ElementsPtr_Type elements = domain->getElementsC();
     vec2D_dbl_ptr_Type pointsRep = domain->getPointsRepeated();
     MapConstPtr_Type map = domain->getMapRepeated();
@@ -4479,9 +2922,9 @@ void FE<SC,LO,GO,NO>::assemblyStress(int dim,
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     int FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 			dPhi;
     vec_dbl_ptr_Type			weightsDPhi = Teuchos::rcp(new vec_dbl_Type(0));
@@ -4813,11 +3256,11 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingBoundaryPaper(int dim,
                                               ParameterListPtr_Type params,
                                               int FEloc) {
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    ElementsPtr_Type elementsPressure = domainVec_.at(FEloc+1)->getElementsC();
+    ElementsPtr_Type elementsPressure = this->domainVec_.at(FEloc+1)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
     vec2D_dbl_ptr_Type phi;
 
@@ -4894,7 +3337,7 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingBoundaryPaper(int dim,
     if(funcParameter[0]+1e-12 >= unsteadyStart){
         p_ref = p_ref - std::pow( (std::sqrt(density)/(2*std::sqrt(2)) * flowRateInput/areaOutlet_T + std::sqrt(beta*std::sqrt(areaOutlet_T))),2) + beta*std::sqrt(areaOutlet_T);
 
-        if(domainVec_.at(0)->getComm()->getRank()==0){
+        if(this->domainVec_.at(0)->getComm()->getRank()==0){
             std::cout << " ---------------------------------------------------------- " <<std::endl;
             std::cout << " ----------------  Start of unsteady phase ---------------- " <<std::endl;
             std::cout << " Reference pressure adjusted from " << p_ref_input << " to " << p_ref <<std::endl;
@@ -4919,7 +3362,7 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingBoundaryPaper(int dim,
 
     //         h_x=  pow( (sqrt(density)/(2*sqrt(2)) * flowRateUse/areaOutlet + sqrt(beta*sqrt(areaOutlet_init))),2) - beta*sqrt(areaOutlet_init) + p_ref;
 
-    if(domainVec_.at(0)->getComm()->getRank()==0){
+    if(this->domainVec_.at(0)->getComm()->getRank()==0){
         std::cout << " ---------------------------------------------------------- " <<std::endl;
         std::cout << " ---------------------------------------------------------- " <<std::endl;
         std::cout << " Absorbing Boundary Condition " <<std::endl;
@@ -4952,9 +3395,9 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingBoundaryPaper(int dim,
                     vec_int_Type nodeList = feSub.getVectorNodeListNonConst ();
                     vec_int_Type nodeListP = elementsPressure->getElement(T).getSubElements()->getElement(surface).getVectorNodeListNonConst();
                     int numNodes_T = nodeList.size();
-                    vec_dbl_Type solution_u = getSolution(nodeList, u_rep,dim);
+                    vec_dbl_Type solution_u = this->getSolution(nodeList, u_rep,dim);
                     vec2D_dbl_Type nodes;
-                    nodes = getCoordinates(nodeList, pointsRep);
+                    nodes = this->getCoordinates(nodeList, pointsRep);
 
                     vec_dbl_Type p1(dim),p2(dim),v_E(dim,1.);
 
@@ -5031,11 +3474,11 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingBoundary(int dim,
                                               ParameterListPtr_Type params,
                                               int FEloc) {
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    ElementsPtr_Type elementsPressure = domainVec_.at(FEloc+1)->getElementsC();
+    ElementsPtr_Type elementsPressure = this->domainVec_.at(FEloc+1)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
     vec2D_dbl_ptr_Type phi;
 
@@ -5123,7 +3566,7 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingBoundary(int dim,
     if(isNeg==1)
         flowRateUse = 0.;
 
-    if(domainVec_.at(0)->getComm()->getRank()==0){
+    if(this->domainVec_.at(0)->getComm()->getRank()==0){
         std::cout << " ---------------------------------------------------------- " <<std::endl;
         std::cout << " ----------------  computing p_ref ---------------- " <<std::endl;
         std::cout << " Reference pressure adjusted from " << p_ref_input << " to " << p_ref <<std::endl;
@@ -5134,7 +3577,7 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingBoundary(int dim,
 
     //         h_x=  pow( (sqrt(density)/(2*sqrt(2)) * flowRateUse/areaOutlet + sqrt(beta*sqrt(areaOutlet_init))),2) - beta*sqrt(areaOutlet_init) + p_ref;
 
-    if(domainVec_.at(0)->getComm()->getRank()==0){
+    if(this->domainVec_.at(0)->getComm()->getRank()==0){
         std::cout << " ---------------------------------------------------------- " <<std::endl;
         std::cout << " ---------------------------------------------------------- " <<std::endl;
         std::cout << " Absorbing Boundary Condition " <<std::endl;
@@ -5163,9 +3606,9 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingBoundary(int dim,
                     vec_int_Type nodeList = feSub.getVectorNodeListNonConst ();
                     vec_int_Type nodeListP = elementsPressure->getElement(T).getSubElements()->getElement(surface).getVectorNodeListNonConst();
                     int numNodes_T = nodeList.size();
-                    vec_dbl_Type solution_u = getSolution(nodeList, u_rep,dim);
+                    vec_dbl_Type solution_u = this->getSolution(nodeList, u_rep,dim);
                     vec2D_dbl_Type nodes;
-                    nodes = getCoordinates(nodeList, pointsRep);
+                    nodes = this->getCoordinates(nodeList, pointsRep);
 
                     vec_dbl_Type p1(dim),p2(dim),v_E(dim,1.);
 
@@ -5237,11 +3680,11 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingResistanceBoundary(int dim,
                                               ParameterListPtr_Type params,
                                               int FEloc) {
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    ElementsPtr_Type elementsPressure = domainVec_.at(FEloc+1)->getElementsC();
+    ElementsPtr_Type elementsPressure = this->domainVec_.at(FEloc+1)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
     vec2D_dbl_ptr_Type phi;
 
@@ -5323,7 +3766,7 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingResistanceBoundary(int dim,
     double h_x =  pow( (sqrt(density)/(2*sqrt(2)) * flowRateUse/areaOutlet + sqrt(beta)),2) - beta + p_ref;
 
     
-    if(domainVec_.at(0)->getComm()->getRank()==0){
+    if(this->domainVec_.at(0)->getComm()->getRank()==0){
         std::cout << " ---------------------------------------------------------- " <<std::endl;
         std::cout << " ---------------------------------------------------------- " <<std::endl;
         std::cout << " Absorbing Boundary Condition " <<std::endl;
@@ -5351,9 +3794,9 @@ double FE<SC,LO,GO,NO>::assemblyAbsorbingResistanceBoundary(int dim,
                     vec_int_Type nodeList = feSub.getVectorNodeListNonConst ();
                     vec_int_Type nodeListP = elementsPressure->getElement(T).getSubElements()->getElement(surface).getVectorNodeListNonConst();
                     int numNodes_T = nodeList.size();
-                    vec_dbl_Type solution_u = getSolution(nodeList, u_rep,dim);
+                    vec_dbl_Type solution_u = this->getSolution(nodeList, u_rep,dim);
                     vec2D_dbl_Type nodes;
-                    nodes = getCoordinates(nodeList, pointsRep);
+                    nodes = this->getCoordinates(nodeList, pointsRep);
 
                     vec_dbl_Type p1(dim),p2(dim),v_E(dim,1.);
 
@@ -5429,11 +3872,11 @@ double FE<SC,LO,GO,NO>::assemblyResistanceBoundary(int dim,
                                               ParameterListPtr_Type params,
                                               int FEloc) {
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    ElementsPtr_Type elementsPressure = domainVec_.at(FEloc+1)->getElementsC();
+    ElementsPtr_Type elementsPressure = this->domainVec_.at(FEloc+1)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
     vec2D_dbl_ptr_Type phi;
     vec2D_dbl_ptr_Type phi1;
@@ -5495,7 +3938,7 @@ double FE<SC,LO,GO,NO>::assemblyResistanceBoundary(int dim,
 
     func( &x_tmp[0], &valueFunc[0], paramsFunc);
 
-    if(domainVec_.at(0)->getComm()->getRank()==0){
+    if(this->domainVec_.at(0)->getComm()->getRank()==0){
         std::cout << " ---------------------------------------------------------- " << std::endl;
         std::cout << " ---------------------------------------------------------- " << std::endl;
         std::cout << " Resistance Boundary Condition " << std::endl;
@@ -5533,9 +3976,9 @@ double FE<SC,LO,GO,NO>::assemblyResistanceBoundary(int dim,
                     vec_int_Type nodeList = feSub.getVectorNodeListNonConst ();
                     vec_int_Type nodeListP = elementsPressure->getElement(T).getSubElements()->getElement(surface).getVectorNodeListNonConst();
                     int numNodes_T = nodeList.size();
-                    vec_dbl_Type solution_u = getSolution(nodeList, u_rep,dim);
+                    vec_dbl_Type solution_u = this->getSolution(nodeList, u_rep,dim);
                     vec2D_dbl_Type nodes;
-                    nodes = getCoordinates(nodeList, pointsRep);
+                    nodes = this->getCoordinates(nodeList, pointsRep);
 
                     vec_dbl_Type p1(dim),p2(dim),v_E(dim,1.);
 
@@ -5672,9 +4115,9 @@ void FE<SC,LO,GO,NO>::assemblyArea(int dim,
                                     int inflowFlag,
                                     int FEloc){
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
     int inletFlag=inflowFlag; //params->sublist("Parameter Fluid").get("Fluid Flag",4); 
 
@@ -5730,7 +4173,7 @@ void FE<SC,LO,GO,NO>::assemblyArea(int dim,
             }
         }
     }
-    reduceAll<int, double> (*domainVec_.at(0)->getComm(), REDUCE_SUM, areaSurface, outArg (areaSurface));
+    reduceAll<int, double> (*this->domainVec_.at(0)->getComm(), REDUCE_SUM, areaSurface, outArg (areaSurface));
 
     area = areaSurface;
 
@@ -5745,9 +4188,9 @@ int FE<SC,LO,GO,NO>::assemblyFlowRate(int dim,
                                         MultiVectorPtr_Type solution_rep,
                                         int FEloc){
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
     vec2D_dbl_ptr_Type phi;
 
@@ -5785,7 +4228,7 @@ int FE<SC,LO,GO,NO>::assemblyFlowRate(int dim,
                 if(feSub.getFlag() == inletFlag){
                     vec_int_Type nodeList = feSub.getVectorNodeListNonConst ();
                     int numNodes_T = nodeList.size();
-                    vec_dbl_Type solution_u = getSolution(nodeList, solution_rep,dofs);
+                    vec_dbl_Type solution_u = this->getSolution(nodeList, solution_rep,dofs);
 
                     
                     vec_dbl_Type p1(dim),p2(dim),v_E(dim,1.);
@@ -5857,8 +4300,8 @@ int FE<SC,LO,GO,NO>::assemblyFlowRate(int dim,
             }
         }
     }
-    reduceAll<int, double> (*domainVec_.at(0)->getComm(), REDUCE_SUM, flowRateInlet, outArg (flowRateInlet));
-    // if(flowRateInlet < 0  && domainVec_.at(0)->getComm()->getRank() == 0)
+    reduceAll<int, double> (*this->domainVec_.at(0)->getComm(), REDUCE_SUM, flowRateInlet, outArg (flowRateInlet));
+    // if(flowRateInlet < 0  && this->domainVec_.at(0)->getComm()->getRank() == 0)
     //     std::cout << " ###### WARNING: the flow rate you computed is negative. Either the surface normal has the wrong orientation, or your solution is negative. Or both :D. Flowrate:"<< flowRateInlet << " ####### " <<std::endl; 
     int isNeg=0;
 
@@ -5880,9 +4323,9 @@ void FE<SC,LO,GO,NO>::assemblyAverageVelocity(int dim,
                                         MultiVectorPtr_Type solution_rep,
                                         int FEloc){
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
     vec2D_dbl_ptr_Type phi;
 
@@ -5920,7 +4363,7 @@ void FE<SC,LO,GO,NO>::assemblyAverageVelocity(int dim,
                 if(feSub.getFlag() == flag){
                     vec_int_Type nodeList = feSub.getVectorNodeListNonConst ();
                     int numNodes_T = nodeList.size();
-                    vec_dbl_Type solution_u = getSolution(nodeList, solution_rep,dofs);
+                    vec_dbl_Type solution_u = this->getSolution(nodeList, solution_rep,dofs);
                     
                     vec_dbl_Type p1(dim),p2(dim),v_E(dim,1.);
                     
@@ -5952,7 +4395,7 @@ void FE<SC,LO,GO,NO>::assemblyAverageVelocity(int dim,
             }
         }
     }
-    reduceAll<int, double> (*domainVec_.at(0)->getComm(), REDUCE_SUM, velocity, outArg (velocity));
+    reduceAll<int, double> (*this->domainVec_.at(0)->getComm(), REDUCE_SUM, velocity, outArg (velocity));
     velocity = velocity/area;
     std::cout << " Average Flowvelocity "<< velocity << " ####### " <<std::endl; 
 
@@ -5973,9 +4416,9 @@ void FE<SC,LO,GO,NO>::assemblyLinElasXDim(int dim,
     int FEloc = this->checkFE(dim,FEType);
 
     // Get elements and node lists
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 			dPhi;
     vec_dbl_ptr_Type			weightsDPhi = Teuchos::rcp(new vec_dbl_Type(0));
@@ -6274,7 +4717,7 @@ void FE<SC,LO,GO,NO>::determineEMod(std::string FEType, MultiVectorPtr_Type solu
     int dim = domain->getDimension();
     vec2D_dbl_ptr_Type pointsRep = domain->getPointsRepeated();
 
-    //MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    //MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     Teuchos::ArrayRCP< const SC > uArray = solution->getData(0);
     Teuchos::ArrayRCP< SC > eModVecA = eModVec->getDataNonConst(0);
@@ -6328,9 +4771,9 @@ void FE<SC,LO,GO,NO>::assemblyLinElasXDimE(int dim,
     int FEloc = this->checkFE(dim,FEType);
 
     // Get elements and node lists
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
 
     vec3D_dbl_ptr_Type 			dPhi;
     vec_dbl_ptr_Type			weightsDPhi = Teuchos::rcp(new vec_dbl_Type(0));
@@ -6639,7 +5082,7 @@ void FE<SC,LO,GO,NO>::assemblyAdditionalConvection(int dim,
     TEUCHOS_TEST_FOR_EXCEPTION(FEType == "P0",std::logic_error, "Not implemented for P0");
     int FEloc = this->checkFE(dim,FEType);
 
-    DomainConstPtr_Type domain = domainVec_.at(FEloc);
+    DomainConstPtr_Type domain = this->domainVec_.at(FEloc);
     ElementsPtr_Type elements = domain->getElementsC();
     vec2D_dbl_ptr_Type pointsRep = domain->getPointsRepeated();
     MapConstPtr_Type map = domain->getMapRepeated();
@@ -6849,7 +5292,7 @@ void FE<SC,LO,GO,NO>::assemblyDummyCoupling(int dim,
                                           int FEloc, // 0 = Fluid, 2 = Struktur
                                           bool callFillComplete)
 {
-    DomainConstPtr_Type domain = domainVec_.at(FEloc);
+    DomainConstPtr_Type domain = this->domainVec_.at(FEloc);
     
     MapConstPtr_Type mapInterfaceVecField = domain->getInterfaceMapVecFieldUnique(); // Interface-Map in der Interface-Nummerierung
     MapConstPtr_Type mapGlobalInterfaceVecField = domain->getGlobalInterfaceMapVecFieldUnique(); // Interface-Map in der globalen Nummerierung
@@ -6891,7 +5334,7 @@ void FE<SC,LO,GO,NO>::assemblyFSICoupling(int dim,
 {
     // int FEloc = this->checkFE(dim,FEType);
 
-    DomainConstPtr_Type domain1 = domainVec_.at(FEloc1);
+    DomainConstPtr_Type domain1 = this->domainVec_.at(FEloc1);
 
     MapConstPtr_Type mapInterfaceVecField = domain1->getInterfaceMapVecFieldUnique(); // Interface-Map in der Interface-Nummerierung
 
@@ -6961,7 +5404,7 @@ void FE<SC,LO,GO,NO>::assemblyGeometryCoupling(int dim,
                               bool callFillComplete)
 {
 
-    DomainConstPtr_Type domain = domainVec_.at(FEloc);
+    DomainConstPtr_Type domain = this->domainVec_.at(FEloc);
 
     MapConstPtr_Type mapInt = domain->getGlobalInterfaceMapVecFieldUnique(); // Interface-Map in der globalen Nummerierung
     MapConstPtr_Type mapOtherInt = domain->getOtherGlobalInterfaceMapVecFieldUnique(); // Interface-Map in der globalen Nummerierung von other. For FELoc=0 or =4, otherInterface has solid dofs
@@ -7010,7 +5453,7 @@ void FE<SC,LO,GO,NO>::assemblyShapeDerivativeVelocity(int dim,
 {
     // int FEloc = this->checkFE(dim,FEType1);
 
-    DomainConstPtr_Type domain = domainVec_.at(FEloc);
+    DomainConstPtr_Type domain = this->domainVec_.at(FEloc);
     ElementsPtr_Type elements = domain->getElementsC();
     vec2D_dbl_ptr_Type pointsRep = domain->getPointsRepeated();
     MapConstPtr_Type map = domain->getMapRepeated();
@@ -7842,13 +6285,13 @@ void FE<SC,LO,GO,NO>::assemblyShapeDerivativeDivergence(int dim,
                                        MultiVectorPtr_Type u, // Geschwindigkeit
                                        bool callFillComplete)
 {
-    DomainConstPtr_Type domain1 = domainVec_.at(FEloc1);
+    DomainConstPtr_Type domain1 = this->domainVec_.at(FEloc1);
     ElementsPtr_Type elements = domain1->getElementsC();
     vec2D_dbl_ptr_Type pointsRep = domain1->getPointsRepeated();
     MapConstPtr_Type map1_rep = domain1->getMapRepeated();
 
     // Fuer die Fluid-Velocity-Map
-    DomainConstPtr_Type domain2 = domainVec_.at(FEloc2);
+    DomainConstPtr_Type domain2 = this->domainVec_.at(FEloc2);
     MapConstPtr_Type map2_rep = domain2->getMapRepeated();
     ElementsPtr_Type elements2 = domain2->getElementsC();
 
@@ -8106,9 +6549,9 @@ void FE<SC,LO,GO,NO>::assemblySurfaceIntegralExternal(int dim,
                                               ParameterListPtr_Type params,
                                               int FEloc) {
     
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
     SC elScaling;
     SmallMatrix<SC> B(dim);
@@ -8133,9 +6576,9 @@ void FE<SC,LO,GO,NO>::assemblySurfaceIntegralExternal(int dim,
                 vec_int_Type nodeList = feSub.getVectorNodeListNonConst ();
 
             
-		        vec_dbl_Type solution_d = getSolution(nodeList, d_rep,dim);
+		        vec_dbl_Type solution_d = this->getSolution(nodeList, d_rep,dim);
                 vec2D_dbl_Type nodes;
-		        nodes = getCoordinates(nodeList, pointsRep);
+		        nodes = this->getCoordinates(nodeList, pointsRep);
 
 
                 double positions[18];
@@ -8193,11 +6636,11 @@ void FE<SC,LO,GO,NO>::assemblyNonlinearSurfaceIntegralExternal(int dim,
     
     // degree of function funcParameter[0]
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
     SC elScaling;
     SmallMatrix<SC> B(dim);
     vec_dbl_Type b(dim);
@@ -8217,9 +6660,9 @@ void FE<SC,LO,GO,NO>::assemblyNonlinearSurfaceIntegralExternal(int dim,
             if(subEl->getDimension() == dim-1 ){
                 vec_int_Type nodeList = feSub.getVectorNodeListNonConst ();
 
-		        vec_dbl_Type solution_d = getSolution(nodeList, d_rep,dim);
+		        vec_dbl_Type solution_d = this->getSolution(nodeList, d_rep,dim);
                 vec2D_dbl_Type nodes;
-		        nodes = getCoordinates(nodeList, pointsRep);
+		        nodes = this->getCoordinates(nodeList, pointsRep);
 
 
                 double positions[18];
@@ -8302,45 +6745,10 @@ void FE<SC,LO,GO,NO>::assemblyNonlinearSurfaceIntegralExternal(int dim,
         }
     }
     //f->scale(-1.);
-    Kext->fillComplete(domainVec_.at(FEloc)->getMapVecFieldUnique(),domainVec_.at(FEloc)->getMapVecFieldUnique());
+    Kext->fillComplete(this->domainVec_.at(FEloc)->getMapVecFieldUnique(),this->domainVec_.at(FEloc)->getMapVecFieldUnique());
 }
 
-/// Compute Surface Normal based on surface nodes,
-template <class SC, class LO, class GO, class NO>
-void FE<SC,LO,GO,NO>::computeSurfaceNormal(int dim,
-                                            vec2D_dbl_ptr_Type pointsRep,
-                                            vec_int_Type nodeList,
-                                            vec_dbl_Type &v_E,
-                                            double &norm_v_E)
-{
 
-    vec_dbl_Type p1(dim),p2(dim);
-
-    if(dim==2){
-        v_E[0] = pointsRep->at(nodeList[0]).at(1) - pointsRep->at(nodeList[1]).at(1);
-        v_E[1] = -(pointsRep->at(nodeList[0]).at(0) - pointsRep->at(nodeList[1]).at(0));
-        norm_v_E = std::sqrt(std::pow(v_E[0],2)+std::pow(v_E[1],2));	
-        
-    }
-    else if(dim==3){
-
-        p1[0] = pointsRep->at(nodeList[0]).at(0) - pointsRep->at(nodeList[1]).at(0);
-        p1[1] = pointsRep->at(nodeList[0]).at(1) - pointsRep->at(nodeList[1]).at(1);
-        p1[2] = pointsRep->at(nodeList[0]).at(2) - pointsRep->at(nodeList[1]).at(2);
-
-        p2[0] = pointsRep->at(nodeList[0]).at(0) - pointsRep->at(nodeList[2]).at(0);
-        p2[1] = pointsRep->at(nodeList[0]).at(1) - pointsRep->at(nodeList[2]).at(1);
-        p2[2] = pointsRep->at(nodeList[0]).at(2) - pointsRep->at(nodeList[2]).at(2);
-
-        v_E[0] = p1[1]*p2[2] - p1[2]*p2[1];
-        v_E[1] = p1[2]*p2[0] - p1[0]*p2[2];
-        v_E[2] = p1[0]*p2[1] - p1[1]*p2[0];
-        
-        norm_v_E = std::sqrt(std::pow(v_E[0],2)+std::pow(v_E[1],2)+std::pow(v_E[2],2));
-        
-    }
-
-}
 
 template <class SC, class LO, class GO, class NO>
 void FE<SC,LO,GO,NO>::assemblySurfaceIntegral(int dim,
@@ -8352,13 +6760,13 @@ void FE<SC,LO,GO,NO>::assemblySurfaceIntegral(int dim,
     
     // degree of function funcParameter[0]
     //TEUCHOS_TEST_FOR_EXCEPTION( funcParameter[funcParameter.size()-1] > 0., std::logic_error, "We only support constant functions for now.");
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
     vec2D_dbl_ptr_Type phi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
 
@@ -8457,13 +6865,13 @@ void FE<SC,LO,GO,NO>::assemblySurfaceIntegralFlag(int dim,
 // degree of function funcParameter[0]
     TEUCHOS_TEST_FOR_EXCEPTION(funcParameter[0]!=0,std::logic_error, "We only support constant functions for now.");
     
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
     vec2D_dbl_ptr_Type phi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
     UN degFunc = funcParameter[0] + 1.e-14;
@@ -8554,13 +6962,13 @@ void FE<SC,LO,GO,NO>::assemblyRHS( int dim,
     TEUCHOS_TEST_FOR_EXCEPTION( a.is_null(), std::runtime_error, "MultiVector in assemblyConstRHS is null." );
     TEUCHOS_TEST_FOR_EXCEPTION( a->getNumVectors()>1, std::logic_error, "Implement for numberMV > 1 ." );
     UN FEloc;
-    FEloc = checkFE(dim,FEType);
+    FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
     vec2D_dbl_ptr_Type phi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
 
@@ -8656,11 +7064,11 @@ void FE<SC,LO,GO,NO>::assemblyPressureMeanValue( int dim,
     TEUCHOS_TEST_FOR_EXCEPTION( a.is_null(), std::runtime_error, "Multivector is null." );
 
     UN FEloc;
-    FEloc = checkFE(dim,FEType);
+    FEloc = this->checkFE(dim,FEType);
 
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
 
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
 
     vec2D_dbl_ptr_Type phi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
@@ -8677,7 +7085,7 @@ void FE<SC,LO,GO,NO>::assemblyPressureMeanValue( int dim,
     SmallMatrix<SC> B(dim);
    
     // Repeated version we assemble
-    MultiVectorPtr_Type a_rep = Teuchos::rcp( new MultiVector_Type( domainVec_.at(FEloc)->getMapRepeated(), 1 ) );
+    MultiVectorPtr_Type a_rep = Teuchos::rcp( new MultiVector_Type( this->domainVec_.at(FEloc)->getMapRepeated(), 1 ) );
     a_rep->putScalar(0.);
 	Teuchos::ArrayRCP< SC > values_a = a_rep->getDataNonConst(0);
 
@@ -8719,13 +7127,13 @@ void FE<SC,LO,GO,NO>::assemblyRHSDegTest( int dim,
     TEUCHOS_TEST_FOR_EXCEPTION( a.is_null(), std::runtime_error, "MultiVector in assemblyConstRHS is null." );
     TEUCHOS_TEST_FOR_EXCEPTION( a->getNumVectors()>1, std::logic_error, "Implement for numberMV > 1 ." );
     
-    UN FEloc = checkFE(dim,FEType);
+    UN FEloc = this->checkFE(dim,FEType);
     
-    ElementsPtr_Type elements = domainVec_.at(FEloc)->getElementsC();
+    ElementsPtr_Type elements = this->domainVec_.at(FEloc)->getElementsC();
     
-    vec2D_dbl_ptr_Type pointsRep = domainVec_.at(FEloc)->getPointsRepeated();
+    vec2D_dbl_ptr_Type pointsRep = this->domainVec_.at(FEloc)->getPointsRepeated();
     
-    MapConstPtr_Type map = domainVec_.at(FEloc)->getMapRepeated();
+    MapConstPtr_Type map = this->domainVec_.at(FEloc)->getMapRepeated();
     vec2D_dbl_ptr_Type phi;
     vec_dbl_ptr_Type weights = Teuchos::rcp(new vec_dbl_Type(0));
     Helper::getPhi(phi, weights, dim, FEType, degree);
@@ -8879,30 +7287,6 @@ void FE<SC,LO,GO,NO>::epsilonTensor(vec_dbl_Type &basisValues, SmallMatrix<SC> &
             }
         }
     }
-}
-
-template <class SC, class LO, class GO, class NO>
-int FE<SC,LO,GO,NO>::checkFE(int dim,
-                 std::string FEType){
-
-    int FEloc;
-    std::vector<int> matches;
-    for (int i = 0; i < domainVec_.size(); i++) {
-        if (domainVec_.at(i)->getDimension() == dim)
-            matches.push_back(i);
-    }
-
-    bool found = false;
-    for (int i = 0; i < matches.size();i++) {
-        if (domainVec_.at( matches.at(i) )->getFEType() == FEType) {
-            FEloc = matches.at(i);
-            found = true;
-        }
-    }
-
-    TEUCHOS_TEST_FOR_EXCEPTION(!found, std::logic_error   ,"Combination of dimenson(2/3) and FE Type(P1/P2) not defined yet. Use addFE(domain)");
-
-    return FEloc;
 }
 
 

--- a/feddlib/core/General/DefaultTypeDefs.hpp
+++ b/feddlib/core/General/DefaultTypeDefs.hpp
@@ -7,6 +7,7 @@ typedef double default_sc;
 typedef int default_lo;
 #if defined HAVE_TPETRA_INT_LONG_LONG
 typedef long long default_go;
+#define DEFAULT_GO_IS_LONG_LONG
 #elif !defined HAVE_TPETRA_INT_LONG_LONG && defined HAVE_TPETRA_INT_INT // TODO: [JK] Can this be removed?
 typedef int default_go;
 #else

--- a/feddlib/core/LinearAlgebra/MultiVector.cpp
+++ b/feddlib/core/LinearAlgebra/MultiVector.cpp
@@ -6,6 +6,10 @@
 namespace FEDD {
     template class MultiVector<default_sc, default_lo, default_go, default_no>;
     template class MultiVector<default_lo, default_lo, default_go, default_no>;
+#ifdef DEFAULT_GO_IS_LONG_LONG
+    // TODO: this instantiation of MultiVector is used in amr. Is this necessary or would MultiVector<LO, LO, GO, NO> suffice?                                                                                                                           
+    template class MultiVector<default_go, default_lo, default_go, default_no>;
+#endif
 }
 #endif  // HAVE_EXPLICIT_INSTANTIATION
 #endif


### PR DESCRIPTION
Base class (FE_ElementAssembly) has all functions related to AssembleFEElements -> Element-wise jacobian construction, the derived FE class has all other functions related to the "original" global assembly routines 
- Important: NO code was deleted only moved
- Advantage: Smaller classes 
- Minimal invasive as each Problem/ Specific problem class has through fefactory_ from class FE access to all functions