### PR TITLE
Fix for missing MultiVector instantiation required by amr.

### DIFF
--- a/feddlib/core/General/DefaultTypeDefs.hpp
+++ b/feddlib/core/General/DefaultTypeDefs.hpp
@@ -7,6 +7,7 @@ typedef double default_sc;
 typedef int default_lo;
 #if defined HAVE_TPETRA_INT_LONG_LONG
 typedef long long default_go;
+#define DEFAULT_GO_IS_LONG_LONG
 #elif !defined HAVE_TPETRA_INT_LONG_LONG && defined HAVE_TPETRA_INT_INT // TODO: [JK] Can this be removed?
 typedef int default_go;
 #else

--- a/feddlib/core/LinearAlgebra/MultiVector.cpp
+++ b/feddlib/core/LinearAlgebra/MultiVector.cpp
@@ -6,6 +6,8 @@
 namespace FEDD {
     template class MultiVector<default_sc, default_lo, default_go, default_no>;
     template class MultiVector<default_lo, default_lo, default_go, default_no>;
+    // TODO: this instantiation of MultiVector is used in amr. Is this necessary or would MultiVector<LO, LO, GO, NO> suffice?
+    template class MultiVector<default_go, default_lo, default_go, default_no>;
 }
 #endif  // HAVE_EXPLICIT_INSTANTIATION
 #endif

--- a/feddlib/core/LinearAlgebra/MultiVector.cpp
+++ b/feddlib/core/LinearAlgebra/MultiVector.cpp
@@ -6,8 +6,10 @@
 namespace FEDD {
     template class MultiVector<default_sc, default_lo, default_go, default_no>;
     template class MultiVector<default_lo, default_lo, default_go, default_no>;
-    // TODO: this instantiation of MultiVector is used in amr. Is this necessary or would MultiVector<LO, LO, GO, NO> suffice?
+#ifdef DEFAULT_GO_IS_LONG_LONG
+    // TODO: this instantiation of MultiVector is used in amr. Is this necessary or would MultiVector<LO, LO, GO, NO> suffice?                                                                                                                           
     template class MultiVector<default_go, default_lo, default_go, default_no>;
+#endif
 }
 #endif  // HAVE_EXPLICIT_INSTANTIATION
 #endif


### PR DESCRIPTION
AMR requires integer multivector instantiations MultiVector<GO, LO, GO, NO> and MultiVector<LO, LO, GO, NO> but previously only MultiVector<LO, LO, GO, NO> was actually instantiated. This PR adds the missing instantiation.
Credit to @jakne 