### PR TITLE
Add citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: FEDDLib
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - name: FEDDLib Team
+    email: feddlib-contact@uni-koeln.de
+    website: 'https://feddlib.github.io/'
+repository-code: 'https://github.com/FEDDLib/FEDDLib'
+url: 'https://feddlib.github.io/FEDDLib/'
+abstract: >-
+  FEDDLib (Finite Element and Domain Decomposition Library)
+  – C++ finite element library based on the open source
+  package Trilinos with interfaces to solver packages in
+  Trilinos (e.g., FROSch) and assembly routines from AceGEN.
+keywords:
+  - finite element method
+  - domain decomposition methods
+  - Trilinos
+license: GPL-3.0


### PR DESCRIPTION
Copied from https://citation-file-format.github.io/:
> CITATION.cff files are plain text files with human- and machine-readable citation information for software (and datasets). Code developers can include them in their repositories to let others know how to correctly cite their software.