### PR TITLE
Early vector erase bug in mesh partitioner.

### DIFF
--- a/feddlib/core/Mesh/MeshPartitioner_def.hpp
+++ b/feddlib/core/Mesh/MeshPartitioner_def.hpp
@@ -365,9 +365,9 @@ void MeshPartitioner<SC,LO,GO,NO>::readAndPartitionMesh( int meshNumber ){
     
     makeContinuousElements(elementsMesh, eind_vec, eptr_vec);
 
-    idx_t *eptr = &eptr_vec.at(0);
-    idx_t *eind = &eind_vec.at(0);
-    
+    idx_t *eptr = eptr_vec.data();
+    idx_t *eind = eind_vec.data();
+
     idx_t ncommon;
     int orderSurface;
     if (dim==2) {
@@ -434,10 +434,6 @@ void MeshPartitioner<SC,LO,GO,NO>::readAndPartitionMesh( int meshNumber ){
                 pointsRepIndices.push_back( eind[j] ); // Ids of element nodes, globalIDs
         }
     }
-    // TODO KHo why erase the vectors here? eind points to the underlying array and is used later.
-    eind_vec.erase(eind_vec.begin(), eind_vec.end());
-    eptr_vec.erase(eptr_vec.begin(), eptr_vec.end());
-
     // Sorting ids with global and corresponding local values to create repeated map
     make_unique(pointsRepIndices);
     if (verbose)
@@ -463,9 +459,9 @@ void MeshPartitioner<SC,LO,GO,NO>::readAndPartitionMesh( int meshNumber ){
             int localSurfaceCounter = 0;
             for (int i=0; i<locepart.size(); i++) {
                 std::vector<int> tmpElement;
-                for (int j=eptr[locepart.at(i)]; j<eptr[locepart.at(i)+1]; j++) {
-                    //local indices
-                    int index = mapRepeated->getLocalElement( (long long) eind[j] );
+                for (int j = eptr_vec.at(locepart.at(i)); j < eptr_vec.at(locepart.at(i) + 1); j++) {
+                    // local indices
+                    int index = mapRepeated->getLocalElement(static_cast<GO>(eind_vec.at(j)));
                     tmpElement.push_back(index);
                 }
 		        //std::sort(tmpElement.begin(), tmpElement.end());


### PR DESCRIPTION
eptr_vec and eind_vec are both used by METIS in readAndPartitionMesh(). After partitioning, these vectors were erased, but the values in the underlying storage were still being used after calling vec.erase() via raw pointers.